### PR TITLE
Add JSON dataset from README

### DIFF
--- a/quotes.json
+++ b/quotes.json
@@ -1,0 +1,2237 @@
+[
+  {
+    "text": "# Manthra\n`considerable careful crafty compositions`",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Intellect is not the amount of knowledge created\nbut the percent of possible creations that weren't...",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Storms reveal how skilled a sailor you are.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The ground is even at the foot of the cross.",
+    "author": "N.T. Wright",
+    "tag": []
+  },
+  {
+    "text": "History ended 50 years ago.\nEverything since then is politics.",
+    "author": "W.Currier",
+    "tag": []
+  },
+  {
+    "text": "If you're asked to be a hero, be a hero;\nIf you're not asked to be a hero, be a hero.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Some people, when you give them enough rope, they make a lasso;\nother people, they make a noose.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Magic is science we don't understand.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "No battle plan survives first contact.",
+    "author": "Helmuth von Moltke",
+    "tag": []
+  },
+  {
+    "text": "We must daily make a raid on the inarticulate.",
+    "author": "T.S. Eliot",
+    "tag": []
+  },
+  {
+    "text": "The answer to the question, \"can machines can think?\" is the same as the answer to \"can submarines can swim?\"",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "You blame a final symbolism as the root of your difficulties.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "You're either following someone or you're following anyone.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "I'm only lazy when I have to be.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "I can explain it to you but I can't understand it for you.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "I love synonym rolls, just like grammar used to make.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Tolerance will reach such a level that intelligent people will be banned from thinking so as not to offend imbeciles.",
+    "author": "Dostoievski",
+    "tag": []
+  },
+  {
+    "text": "Intelligence is the creature's ability to use what wits it has.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Without craftsmanship inspiration is a mere reed shaken in the wind.",
+    "author": "Johannes Brahms",
+    "tag": []
+  },
+  {
+    "text": "There are two kinds of pain in this world: pain that hurts and pain that alters.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The two most important days in your life are the day you were born and the day you find out why.",
+    "author": "Mark Twain",
+    "tag": []
+  },
+  {
+    "text": "No amount of money ever bought a second of time.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Repetition has been accepted as a substitute for evidence.",
+    "author": "Thomas Sowell",
+    "tag": []
+  },
+  {
+    "text": "The goalie always makes the last mistake.",
+    "author": "JY",
+    "tag": []
+  },
+  {
+    "text": "The person who doesn't read had no advantage over the person who can't.",
+    "author": "Mark Twain",
+    "tag": []
+  },
+  {
+    "text": "For God so loved the wordi that He did not send a committee.",
+    "author": "2 Hesitations 5:6",
+    "tag": []
+  },
+  {
+    "text": "I finally figured out what's wrong with my brain:\nthere's nothing right on the left side,\nand nothing left on the right side.",
+    "author": "A.Currier",
+    "tag": []
+  },
+  {
+    "text": "They who have put out the people's eyes reproach them of their blindness.",
+    "author": "John Milton",
+    "tag": []
+  },
+  {
+    "text": "The Lord delights to hang great weights on apparently slender wires.",
+    "author": "Jowett",
+    "tag": []
+  },
+  {
+    "text": "Humility is the ladder from which all else is grasped.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "When you board the wrong train,\nit doesn't do any good to run the opposite direction.",
+    "author": "Dietrich Bonhoeffer",
+    "tag": []
+  },
+  {
+    "text": "It\u2019s such a fine line between stupid and clever.",
+    "author": "David St. Hubbins",
+    "tag": []
+  },
+  {
+    "text": "Jesus taught 1st century Jews; any relevance of that to us must start with them.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "A great, a good, and a right mind is a kind of divinity lodged in flesh, and may be the blessing of a slave as well as of a prince.",
+    "author": "Seneca the Younger",
+    "tag": []
+  },
+  {
+    "text": "Art without a transcendental nature always seems less primitive.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "Whoever, therefore, thinks that he understands the Holy Scriptures, or any part of them, but puts such an interpretation upon them as does not tend to build up this twofold love of God and our neighbor, does not yet understand them as he ought.",
+    "author": "Augustine",
+    "tag": []
+  },
+  {
+    "text": "Medicine is the art of amusing the patient while nature heals the injury.",
+    "author": "Voltaire",
+    "tag": []
+  },
+  {
+    "text": "Young conservatives have no heart,\nold liberals have no brain.",
+    "author": "WBC",
+    "tag": []
+  },
+  {
+    "text": "The mark of a trained mind is the ability to entertain ideas without accepting them.",
+    "author": "Aritstotle",
+    "tag": []
+  },
+  {
+    "text": "Confidence is the food of the wise but the liquor of fools.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "We should have more reverence for Scripture than to allow ourselves to transfigure its sense so freely.",
+    "author": "John Calvin",
+    "tag": []
+  },
+  {
+    "text": "You don't get stronger in the gym,\nyou get stronger because of the gym.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "If life gets too hard to stand, kneel.",
+    "author": "Gordon B. Hinckley",
+    "tag": []
+  },
+  {
+    "text": "That is the law according to the rules.",
+    "author": "Dwight Schrute",
+    "tag": []
+  },
+  {
+    "text": "While most of us go through life afraid that people will think too little of us,\n[the apostle] Paul went through life afraid people would think too much of him.",
+    "author": "D. A. Carson",
+    "tag": []
+  },
+  {
+    "text": "Not choosing is choosing the not.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Faith is a recipe from God and you are the secret ingredient.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Encountering the gospel is like getting hit by an 18 wheeler- you're gonna be different.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "One of Jesus' greatest miracles was having 12 friends by the age of 30.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Preach the Gospel at all times.  Use words if necessary.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Contrast is the mother of clarity.",
+    "author": "Oz Guinness",
+    "tag": []
+  },
+  {
+    "text": "The doors of hell are locked on the inside.",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "The world will never starve for want of wonders; but only for want of wonder.",
+    "author": "G.K. Chesterton",
+    "tag": []
+  },
+  {
+    "text": "A sneer is not an argument.",
+    "author": "Jay Wesley Richards",
+    "tag": []
+  },
+  {
+    "text": "You must know your Peter and your Judas;\nPeter has a bad day, Judas had a bad heart;",
+    "author": "Judas you release, Peter you restore.",
+    "tag": []
+  },
+  {
+    "text": "I sat with my anger long enough until she told me her real name was grief.",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "No pain no stimulus, no rest no gain.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "The secret is there is no secret.\nConsistency over intensity;\nProgress over perfection;\nFundamentals over fads.\nOver and over again.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Deeds will not be less valiant because they are unpraised.",
+    "author": "J.R.R. Tolkien",
+    "tag": []
+  },
+  {
+    "text": "People with siblings have better survival skills because they are experienced in physical combat, psychological warfare, and sensing suspicious activity.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "It's not a problem to aim high and miss.\nIt is a problem to aim low and hit.",
+    "author": "Michaelangelo",
+    "tag": []
+  },
+  {
+    "text": "I've never let schooling get in the way of my education.",
+    "author": "Mark Twain",
+    "tag": []
+  },
+  {
+    "text": "Sin will keep us from the Book;\nOr the Book will keep us from sin.",
+    "author": "D.L. Moody",
+    "tag": []
+  },
+  {
+    "text": "You're not a citizn of the world trying to get to heaven,\nyou're a citizn of heaven making your way through the world.",
+    "author": "Vance Havner",
+    "tag": []
+  },
+  {
+    "text": "LORD, what we know not, teach us;\nWhat we have not, give us;\nWhat we are not, make us.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "When a wizard is tired of looking for broken glass in his dinner,\nhe is tired of life.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "When your outgo exceeds your income your upkeep witll be you downfall.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A shroud has no pockets.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A man's wife is his faithful looking glass.",
+    "author": "General Gordon of Cartoum",
+    "tag": []
+  },
+  {
+    "text": "We are not saved by fruit, but by faith;\nbut not by fruitless faith.",
+    "author": "Tim Keller",
+    "tag": []
+  },
+  {
+    "text": "Sow a thought, reap an action;\nSow an action, reap a habit;\nSow a habit, reap a character;\nSow a character, reap a destiny.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Whenever I'm about to do something I think, \"Would an idiot do that?\" and if they would _I do not do that thing_.",
+    "author": "Dwight Schrute",
+    "tag": []
+  },
+  {
+    "text": "Good judgment comes from experience; experience comes from bad judgment.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Our own true best selves are always theoretical.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Courage is not a virtue,\nbut is the form of a virtue being tested.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Before is the soul of lingerie.",
+    "author": "Dorothy Parker",
+    "tag": []
+  },
+  {
+    "text": "Prairie causes you to work not on what you like, but on what you'd like to like.",
+    "author": "Paul Graham",
+    "tag": []
+  },
+  {
+    "text": "He is no fool who gives up what he cannot keep to attain that which he cannot lose.",
+    "author": "Jim Elliott",
+    "tag": []
+  },
+  {
+    "text": "There is something about humility that appeals to my ego.",
+    "author": "Augustine",
+    "tag": []
+  },
+  {
+    "text": "You can easily judge the character of a man by how he treats those who can do nothing for him.",
+    "author": "Johann Wolfgang von Goethe",
+    "tag": []
+  },
+  {
+    "text": "With the first link, the chain is forged.\nThe first speech censured, the first thought forbidden, the first freedom denied,\nchains us all irrevocably.",
+    "author": "Judge Aaron Satie",
+    "tag": []
+  },
+  {
+    "text": "Christians have nothing to be smug about:\nwe're just one beggar telling another where to find bread.",
+    "author": "R.C. Sproul",
+    "tag": []
+  },
+  {
+    "text": "Blessed are those who can give without remembering, and take without forgetting.",
+    "author": "Elizabeth Asquith Bibesco",
+    "tag": []
+  },
+  {
+    "text": "The more often he feels without acting, the less he will be able ever to act, and, in the long run, the less he will be able to feel.",
+    "author": "Screwtape",
+    "tag": []
+  },
+  {
+    "text": "Ruminating on sorrow is bitter work.\nSome things are better to swallow than to chew.",
+    "author": "Charles Spurgeon",
+    "tag": []
+  },
+  {
+    "text": "I will show you how to do the advanced maneuver but you will only be able to perform it when you can do it faster than you can decide to do it.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The greatest weapon against stress is our ability to choose one thought over another.",
+    "author": "William James",
+    "tag": []
+  },
+  {
+    "text": "One thing about being on the precipice:\nthe next step is very clear.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "Everything in moderation including moderation.",
+    "author": "Socrates",
+    "tag": []
+  },
+  {
+    "text": "Don't wait for miracles.\nYour whole life is a miracle.",
+    "author": "Albert Einstein",
+    "tag": []
+  },
+  {
+    "text": "Of two evils, choose neither.",
+    "author": "Charles Sturgeon",
+    "tag": []
+  },
+  {
+    "text": "A rut is a grave with the ends kicked out.",
+    "author": "Earl Nightingale",
+    "tag": []
+  },
+  {
+    "text": "I sense a trap.\nNext move?\nSpring the trap.",
+    "author": "Obi-Wan Kenobi",
+    "tag": []
+  },
+  {
+    "text": "In in response to a book written by 100 critics, \"if I were wrong it would only take one.\"",
+    "author": "Albert Einstein",
+    "tag": []
+  },
+  {
+    "text": "When you go into the end zone,\nact like you've been there before.",
+    "author": "Vince Lombardi",
+    "tag": []
+  },
+  {
+    "text": "Talent hits a target no one else can hit.\nGenius hits a target no one else can see.",
+    "author": "Arthur Schopenhauer",
+    "tag": []
+  },
+  {
+    "text": "I believe in Christianity as I believe the sun has risen;\nnot only because I see it,\nbut because by it I see everything else.",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "You have been chosen, and you must therefore use such strength and heart and wits as you have.",
+    "author": "J.R.R. Tolkien",
+    "tag": []
+  },
+  {
+    "text": "I'm all about loyalty- in fact, part of what I'm being paid for is my loyalty.\nBut if there were somewhere else that values loyalty more highly, I'm going wherever they value loyalty the most.",
+    "author": "Dwight Schrute",
+    "tag": []
+  },
+  {
+    "text": "Don't interrupt your enemy while they are making mistakes.",
+    "author": "Napoleon Bonaparte",
+    "tag": []
+  },
+  {
+    "text": "In academia no one cares what you've done, they only care what you've read.\nIn industry no one cares what you've read, they only care what you've done.",
+    "author": "J. Youngblood",
+    "tag": []
+  },
+  {
+    "text": "Passion is the genesis of genius.",
+    "author": "GALILEO GALILEI",
+    "tag": []
+  },
+  {
+    "text": "Only a fool learns from his own mistakes.\nThe wise man learns from the mistakes of others.",
+    "author": "Otto von Bismarck",
+    "tag": []
+  },
+  {
+    "text": "Give before it hurts.",
+    "author": "Calvin",
+    "tag": []
+  },
+  {
+    "text": "Some people are so poor all they have is money.",
+    "author": "Bob Marley",
+    "tag": []
+  },
+  {
+    "text": "The rule of heaven: thy will be done.\nThe rule of hell: my will be done.",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "The Scriptures are shallow enough for a babe to come and drink without fear of drowning\nand deep enough for theologians to swim in without ever touching the bottom.",
+    "author": "St. Jerome",
+    "tag": []
+  },
+  {
+    "text": "Eve is oft maligned alone for giving Adam the apple,\nbut really is was a bad pear.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Hypocrites do the devil's drudgery in Christ's livery.",
+    "author": "Matthew Henry",
+    "tag": []
+  },
+  {
+    "text": "I heard God's call and I'm pretty sure he was talking to the guy behind me;\nbut I'm going to go ahead and do what He said just in case.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Hell: the greatest monument to human freedom.",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "Jonah sat and waited for God to come around to his way of thinking.\nAll the while God waits for we Jonah's to come around to his way of loving.",
+    "author": "Thomas John Carlisle",
+    "tag": []
+  },
+  {
+    "text": "First they came for the socialists, and I did not speak out\u2014 because I was not a socialist.\nThen they came for the trade unionists, and I did not speak out\u2014 because I was not a trade unionist.\nThen they came for the Jews, and I did not speak out\u2014because I was not a Jew.\nThen they came for me\u2014and there was no one left to speak for me.",
+    "author": "Martin Niem\u00f6ller",
+    "tag": []
+  },
+  {
+    "text": "As a nation of free men we will live forever or die by suicide.",
+    "author": "Abraham Lincoln",
+    "tag": []
+  },
+  {
+    "text": "A metaphor always stands for something real.",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "I was saved; I am saved; I am being saved.",
+    "author": "Earl Rademacher",
+    "tag": []
+  },
+  {
+    "text": "All people, regardless of worldview, are made in the image of God and I intend to treat them that way.",
+    "author": "Lewis Lennox",
+    "tag": []
+  },
+  {
+    "text": "The real conspiracy theorists are the ones who believe the government cares for them, the media would never lie to them, and pharmaceutical companies making billions of dollars selling them drugs want to cure them.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Politics: the art of convincing decent people to forget that the lesser of two evils is still evil.",
+    "author": "Edward Snowden",
+    "tag": []
+  },
+  {
+    "text": "Science takes things apart to see how they work.\nReligion puts things together to see what they mean.\nThey speak different languages and use different powers of the brain.",
+    "author": "Lord Jonathan Sacks",
+    "tag": []
+  },
+  {
+    "text": "Our scars show that we have suffered...and healed.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A writer needs three things, experience, observation, and imagination,\nany two of which, at times any one of which, can supply the lack of the other.",
+    "author": "William Faulkner",
+    "tag": []
+  },
+  {
+    "text": "It does not do to leave a live dragon out of your calculations, if you live near him.",
+    "author": "J.R.R. Tolkien",
+    "tag": []
+  },
+  {
+    "text": "Easy reading is damned hard writing.",
+    "author": "Nathaniel Hawthorne",
+    "tag": []
+  },
+  {
+    "text": "Either write something worth reading or do something worth writing.",
+    "author": "Benjamin Franklin",
+    "tag": []
+  },
+  {
+    "text": "Sometimes ideas just come to me.\nOther times I have to sweat and almost bleed to make ideas come.\nIt\u2019s a mysterious process, but I hope I never find out exactly how it works.",
+    "author": "J.K. Rowling",
+    "tag": []
+  },
+  {
+    "text": "Life is like a helicopter\nI don't know how to operate a helicopter.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Know how to solve every problem that has been solved.",
+    "author": "Richard P. Feynman",
+    "tag": []
+  },
+  {
+    "text": "It would seem our Lord finds our desires not too strong, but too weak.",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "If you want a happy ending, that depends, of course, on where you stop your story.",
+    "author": "Orson Welles",
+    "tag": []
+  },
+  {
+    "text": "When the student is ready the teacher will appear.\nWhen the student is truly ready the teacher will disappear.",
+    "author": "Tao Te Ching",
+    "tag": []
+  },
+  {
+    "text": "A smart person expresses less than 10% of what they think.\nA stupid person thinks about less than 10% of what they express.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "If you don't have time to do it right, when will you have time to do it over?",
+    "author": "John Wooden",
+    "tag": []
+  },
+  {
+    "text": "The greater danger for most of us lies not in setting our aim too high and falling short;\nbut in setting our aim too low, and achieving our mark.",
+    "author": "Michaelangelo",
+    "tag": []
+  },
+  {
+    "text": "War is a place where\nyoung people who don't know each other and don't hate each other\nkill each other\nbased on decisions made by old people who know each other and hate each other\nbut don't kill each other.",
+    "author": "Paul Val\u00e9ry",
+    "tag": []
+  },
+  {
+    "text": "Remember, if you have a problem with your parachute: you have the rest of your life to figure it out.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "When you get what you want that is God's direction.\nWhen you don't get what you want that is God's protection.",
+    "author": "Shannon L. Adler",
+    "tag": []
+  },
+  {
+    "text": "The skill of writing is to create a context in which other people can think.",
+    "author": "Edwin Schlossberg",
+    "tag": []
+  },
+  {
+    "text": "Three contractors are bidding to fix a broken fence at the White House.\nThe Minnesota contractor says, \"I figure the job will run about $900.  $400 for materials, $400 for my crew, and $100 profit.\"\nThe Tennessee contractor says, \"I can do this job for $700. $300 for materials, $300 for my crew, and $100 profit.\"\nThe Chicago contractor leans over to the White House official and whispers, \"$2,700.\"\nThe official, incredulous, says, \"You didn't even measure like the other guys!  How did you come up with such a high figure?\"\nThe Chicago contractor whispers back, \"$1000 for me, $1000 for you, and we hire the guy from Tennessee to fix the fence.\"",
+    "author": "\"Done!\" replies the government official. And that, my friends, is how our government works.",
+    "tag": []
+  },
+  {
+    "text": "The United States had become a place where entertainers and professional athletes were mistaken for people of importance.\nThey were idolized and treated as leaders; their opinions were sought on everything and they took themselves just as seriously\u2014\nafter all, if an athlete is paid a million or more a year, he knows he is important\u2026\nso his opinions of foreign affairs and domestic policies must be important, too, even though he proves himself to be both ignorant and subliterate every time he opens his mouth.\n(Most of his fans were just as ignorant and unlettered; the disease was spreading.)",
+    "author": "Robert A. Heinlein - To Sail Beyond the Sunset 1987",
+    "tag": []
+  },
+  {
+    "text": "If you want to know who controls you,\nlook at who you are not allowed to criticize.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Never appeal to a man's better nature,\nhe may not have one.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A civilization which leaves so large a number of its participants unsatisfied\nand drives them into revolt\nneither has nor deserves the prospect of a lasting existence.",
+    "author": "Sigmund Freud",
+    "tag": []
+  },
+  {
+    "text": "Don't mistake my generosity for generosity.",
+    "author": "whiterose",
+    "tag": []
+  },
+  {
+    "text": "If someone shows you who they really are...\nbelieve them.\nMr. Eisenhut",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The true character of a man is decided in the battle between him and his fallen nature;\nThe only real victory is to deny it battle.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Perhaps I am a providential shipwreck.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "In Sterquiliniis Invenitur\n__In filth it will be found__",
+    "author": "Carl Jung",
+    "tag": []
+  },
+  {
+    "text": "With powerlessness comes agression.",
+    "author": "Andrew Huberman",
+    "tag": []
+  },
+  {
+    "text": "Cowards and champions have the same fears.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Be willing to do today was others aren't,\nSo that you're able to do tomorrow what others can't.",
+    "author": "Matt Fraser",
+    "tag": []
+  },
+  {
+    "text": "Never use too many over-the-top, superfluous, excessively narrow, hypersyllabic adjectives.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "One of the main functions of organized religion is to protect people against a direct experience of God.",
+    "author": "Carl Jung",
+    "tag": []
+  },
+  {
+    "text": "If it's not counted then it doesn't count.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Look to the horizon but watch your step.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "One out of one of us will die; and one of us will be the next one.",
+    "author": "Sam Cherian",
+    "tag": []
+  },
+  {
+    "text": "Of every hundred men in war:\nten shouldn't be there,\neighty are nothing but targets,\nnine are real fighters, and we are lucky to have them, for they make the battle.\nAh, but the one, one is a warrior, and he will bring the others back.",
+    "author": "Herman Melville",
+    "tag": []
+  },
+  {
+    "text": "Nature is a book written in \u201cthe language of mathematics\u201d.\nIf we cannot understand that language, we will be doomed to wander about as if in a dark labyrinth.",
+    "author": "Galileo Galilei",
+    "tag": []
+  },
+  {
+    "text": "Providence is the belief that all of history has been orchestrated to bring you into the presence of God at this very moment- and that every human can claim this.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "Give us one free miracle and we'll explain the rest.",
+    "author": "Terrance McKenna",
+    "tag": []
+  },
+  {
+    "text": "If an apple falls from a tree because of a law of nature,\nThen is it not a person and, further, a citizen.",
+    "author": "C.S. Lewis.",
+    "tag": []
+  },
+  {
+    "text": "As soon as you say never here come the kids nevering like they never nevered before.",
+    "author": "Erma Bombeck",
+    "tag": []
+  },
+  {
+    "text": "If men define situations as real,\nthey are real in their consequences.",
+    "author": "The Thomas Theorem",
+    "tag": []
+  },
+  {
+    "text": "The only person who never makes a mistake is the person who does nothing.",
+    "author": "Albert Einstein",
+    "tag": []
+  },
+  {
+    "text": "A correct decision is wrong when it's made too late.",
+    "author": "Lee Iococa",
+    "tag": []
+  },
+  {
+    "text": "Everybody counts or nobody counts.",
+    "author": "Heironymous Bosch",
+    "tag": []
+  },
+  {
+    "text": "At the end of the day a man is no better than the pain he has caused the one's he loves;\nAnd what he has done to make it better.",
+    "author": "Rycroft Philostrate",
+    "tag": []
+  },
+  {
+    "text": "If I have seen further it is by standing on the shoulders of giants.",
+    "author": "Isaac Newton",
+    "tag": []
+  },
+  {
+    "text": "Nothing is more certain than death,\nAnd nothing more uncertain than the time of death.",
+    "author": "Thomas Paine",
+    "tag": []
+  },
+  {
+    "text": "It is amazing how complete is the delusion that beauty is goodness.",
+    "author": "Leo Tolstoy",
+    "tag": []
+  },
+  {
+    "text": "Everyone has the right to be stupid,\nSome people abuse the privilege.",
+    "author": "Joseph Stalin",
+    "tag": []
+  },
+  {
+    "text": "Capitalism is people exploiting people,\nUnder communism it's exactly the opposite.",
+    "author": "...",
+    "tag": []
+  },
+  {
+    "text": "The Bible is the greatest of all books; to study it is the noblest of all pursuits; to understand it, the highest of all goals.",
+    "author": "Charlie Ryrie.",
+    "tag": []
+  },
+  {
+    "text": "It does not do to dwell on dreams and forget to live.",
+    "author": "Albus Dumbledore",
+    "tag": []
+  },
+  {
+    "text": "You're unique, just like everyone else.",
+    "author": "Margaret Mead",
+    "tag": []
+  },
+  {
+    "text": "How you get there's the worthier part.",
+    "author": "Shepherd Book",
+    "tag": []
+  },
+  {
+    "text": "Never doubt that a small group of thoughtful, committed citizens can change the world;\nindeed, it's the only thing that ever has.",
+    "author": "Margaret Mead",
+    "tag": []
+  },
+  {
+    "text": "The world will accept the judgment you place upon yourself.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "An outsider is a catalyst:\nEssential and often burned up in process.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Have strong opinions, loosely held,\nIf you want to influence your neighbor.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "More important thean learning the truth,\nIs to unlearn what is untrue.",
+    "author": "Antisthenes",
+    "tag": []
+  },
+  {
+    "text": "Before you say something negative about someone else\nSay something negative about yourself.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "What gets us in trouble is not what we know-\nIt's what we know for sure that just ain't so.",
+    "author": "Mark Twain",
+    "tag": []
+  },
+  {
+    "text": "Democracy is the distribution of power.\nTyranny is the concentration of power.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "English is what happens when Vikings learn Latin and use it to shout at Germans.",
+    "author": "Kevin McLeod",
+    "tag": []
+  },
+  {
+    "text": "There are 2 kinds of people on this world:\nThose who can extrapolate from limited data,",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "If there's one thing I learned in the army:\nIt's to be positive,\nespecially when you don't know what you're talking about.",
+    "author": "Major General Waverly",
+    "tag": []
+  },
+  {
+    "text": "The mystery is not that God hated Esau;\nBut that God loved Jacob.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Nobody owns life but anyone who holds a frying pan holds death.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "You can't pickpocket a naked man.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "No one is against you,\nthey are for themselves.",
+    "author": "M. Calderon",
+    "tag": []
+  },
+  {
+    "text": "Dictionary, n. A malevolent literary device for cramping the growth of a language and making it hard and inelastic.",
+    "author": "Ambrose Bierce",
+    "tag": []
+  },
+  {
+    "text": "Fear has two meanings:\nForget Everything And Run\nor",
+    "author": "Face Everything And Rise",
+    "tag": []
+  },
+  {
+    "text": "A man's reach should exceed his grasp, or what's a heaven for?",
+    "author": "Robert Browning",
+    "tag": []
+  },
+  {
+    "text": "At the end of the day you have to make a choice:\nWhether to live with yourself or be happy.",
+    "author": "Michael Scott",
+    "tag": []
+  },
+  {
+    "text": "If _onlys_ and _justs_ were candies and nuts then everyday would be Erntedankfest.",
+    "author": "Dwight Schrute",
+    "tag": []
+  },
+  {
+    "text": "We need to stop just pulling people out of the river,\nWe need to go upstream and find out why they're falling in.",
+    "author": "Desmond Tutu",
+    "tag": []
+  },
+  {
+    "text": "When you're successful you have everything you need,\nWhen you're fulfilled your give everything you've got.",
+    "author": "Keith Cunningham",
+    "tag": []
+  },
+  {
+    "text": "To suffer terribly and know yourself as the cause, that is hell.",
+    "author": "Jordan Peterson",
+    "tag": []
+  },
+  {
+    "text": "Intuition is a powerful tonic.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "I don't trust someone who is nice to me but rude to the waiter;\nBecause they would treat me the same way if I was in that position.",
+    "author": "Muhammad Ali",
+    "tag": []
+  },
+  {
+    "text": "Trust those who seek the truth,\nDoubt those who claim they have found it.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "How to politely tell someone they're stupid:\n__Wisdom has always been chasing you, but you've always been faster__",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Wine tastes sweetest to those in whose trials it was fermented.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "If, for some reason your life functions ceased, my most precious one,\nI would collapse, I would draw the shades and I would live in the dark.\nI would never get out of my slar pad or clean myself.\nMy fluids would coagulate, my cone would shrivel,\nand I would die, miserable and lonely.\nThe stench would be great.",
+    "author": "Baldar Conehead",
+    "tag": []
+  },
+  {
+    "text": "People change when\nthey hurt enough they have to,\nthey see enough they're inspired to,\nthey learn enough they want to,\nthey recieve enough they're able to.",
+    "author": "John C. Maxwell",
+    "tag": []
+  },
+  {
+    "text": "If you love a flower, don't pick it up.\nBecause if you pick it up it dies and it ceases to be what you love.\nSo if you love a flower, let it be.",
+    "author": "Osho",
+    "tag": []
+  },
+  {
+    "text": "Mathematics is the science of analogy.",
+    "author": "Atiyah",
+    "tag": []
+  },
+  {
+    "text": "You cannot change your mind with your mind.\nYou can only change your mind with your body.",
+    "author": "Alan Huberman",
+    "tag": []
+  },
+  {
+    "text": "our preferences do not determine what's true.",
+    "author": "Carl Sagan",
+    "tag": []
+  },
+  {
+    "text": "Don't pretend to be what you're not, instead, pretend to what you want to be, it is not pretence, it is a journey to self realization.",
+    "author": "Michael Bassey Johnson",
+    "tag": []
+  },
+  {
+    "text": "You can tell all you need to know about a man's character by how he speaks to his children and how his wife speaks to him.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "The goal of a narcissist is to attain moral virtue without undergoing any of the suffering necessary to attain it.",
+    "author": "Jordan Peterson",
+    "tag": []
+  },
+  {
+    "text": "A candle doesn't lose any flame by lighting another candle.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "I can't believe what you say\nbecause I see what you do.",
+    "author": "James Baldwin",
+    "tag": []
+  },
+  {
+    "text": "Those who can make you believe absurdities\ncan make your commit atrocities.",
+    "author": "Voltaire",
+    "tag": []
+  },
+  {
+    "text": "A lie doesn\u2019t become truth,\nwrong doesn\u2019t become right\nand evil doesn\u2019t become good\njust because it\u2019s accepted by a majority.",
+    "author": "Booker T. Washington.",
+    "tag": []
+  },
+  {
+    "text": "Challenge fear;\nOvercome it;\nBut deny it at your peril.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Smooth seas do not make skilled sailors.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "English is hopelessly complicated, extra letters and redundant vowels, like 'gh' and 'ou', abond.\nAs wel, certin leters, like 'c' and 'y', have multyple fonymz wich mace them unycycary.\nAlso, cyrtn condz, like 'th' and 'sh', can be ynferd witot te xtra lytr.\nI kanot fathym a mor frynytic kakofony of grafymc tan tyz,\nTo a cyrtin potry yxysts yn yts complyxty- arysng and rysydyng yn ty mynd of bot atr an redr.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "One shan't rely on the written word alone:\nIf you read read as read instead of read your to-do becomes done without doing.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "The problem with quotes found on the Internet\nis that they are often not true.",
+    "author": "Abraham Lincoln",
+    "tag": []
+  },
+  {
+    "text": "Tolerance will reach such a level\nthat intelligent people will be banned from thinking\nso as not to offend the imbecile.",
+    "author": "Dostoievski.",
+    "tag": []
+  },
+  {
+    "text": "It is only when a mosquito lands on your testicles that you realize\nthere is always a way to solve problems without violence.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Money attracts the woman you want,\nstruggle attracts the woman you need.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "First do it, then do it right, then do it better.",
+    "author": "Addy Osmani",
+    "tag": []
+  },
+  {
+    "text": "Morality is doing what's right in spite of what you're told.\nObedience is doing what you're told in spite of what's right.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "You are better off hurt than hardened.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Plans are worthless, but planning is essential.",
+    "author": "Dwight Eisenhower",
+    "tag": []
+  },
+  {
+    "text": "No one is going to give you the education you need to overthrow them.\nNobody is going to teach you your true history,\nteach you your true heroes,\nif they know that that knowledge will help set you free.",
+    "author": "Assata Shakur",
+    "tag": []
+  },
+  {
+    "text": "When the devil ignores you,\nyou know you're doing something wrong.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Compliance is doing what another wants,\nSubmission is making their wants your own.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "Bad leadership is unbiblical.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "Don't fight unless you have to.\nBut if you have to then fight like you're the third monkey on the ramp to Noah's ark and, brother, it's starting to rain...",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Don\u2019t wear yourself out wrestling with a pig.\nYou just get muddy and the pig likes it.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "All science is either physics or stamp collecting.",
+    "author": "Ernest Rutherford",
+    "tag": []
+  },
+  {
+    "text": "We simply cannot maintain wholeness\nif we talk and walk differently\nthan we see.",
+    "author": "Stephen Covey",
+    "tag": []
+  },
+  {
+    "text": "What you are shouts so loudly in my ears\nI cannot hear what you say.",
+    "author": "Emerson",
+    "tag": []
+  },
+  {
+    "text": "If God wants to teach you peace,\nhe\u2019ll put you in chaos.\nIf God wants you to learn love,\nhe\u2019ll put you around an unlovely person.",
+    "author": "Rick Warren",
+    "tag": []
+  },
+  {
+    "text": "When you feel...\n...angry, go exercise\n...envy, meditate\n...anxiety, give thanks\n...irritation, ruminate\n...tired, go-to bed\n...uninspired, take a shower\n...doubtful, write",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A leader is one of whom it will be said, he was one of them but demonstrably in charge.",
+    "author": "Stanley McCrystal.",
+    "tag": []
+  },
+  {
+    "text": "I can afford nouns, but adjectives are expensive.",
+    "author": "Jimmy Youngblood",
+    "tag": []
+  },
+  {
+    "text": "Being powerful is like being a lady.\nIf you have to tell people you are, you aren't.",
+    "author": "Margaret Thatcher",
+    "tag": []
+  },
+  {
+    "text": "Our talents are living things.\nWe give birth to them, nourish them,\ntill they grow and become immortal.",
+    "author": "Michael Bassey Johnson",
+    "tag": []
+  },
+  {
+    "text": "Never underestimate the man who overestimates himself.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "It is easier to find men who will volunteer to die,\nthan to find those who are willing to endure pain with patience.",
+    "author": "Caesar Augustus",
+    "tag": []
+  },
+  {
+    "text": "Libertarians fight for freedom,\nLiberals fight for the helpless,\nConservatives fight for civilization;\nAll three are entirely necessary.",
+    "author": "Michael Shellenberger",
+    "tag": []
+  },
+  {
+    "text": "If you don't have friends who are not like you then you're in trouble.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "To know that we know what we know, and that we do not know what we do not know, that is true knowledge.",
+    "author": "Confuscius",
+    "tag": []
+  },
+  {
+    "text": "We have no more right to consume happiness without producing it than to consume wealth without producing it.",
+    "author": "George Bernard Shaw",
+    "tag": []
+  },
+  {
+    "text": "Life contains but two tragedies.\nOne is not to get your heart\u2019s desire;\nthe other is to get it.",
+    "author": "George Bernard Shaw",
+    "tag": []
+  },
+  {
+    "text": "Until you understand a writer's ignorance,\npresume yourself ignorant of his understanding.",
+    "author": "Samuel Taylor Coleridge",
+    "tag": []
+  },
+  {
+    "text": "If you presume to love something,\nyou must love the process of it much more than you love the finished product.",
+    "author": "John Irving",
+    "tag": []
+  },
+  {
+    "text": "If you can walk with the crowd and keep your virtue,\nor walk with Kings- nor lose the common touch;\nIf neither foes nor loving friends can hurt you;\nIf all men count with you, but none too much;\nIf you can fill the unforgiving minute with 60 seconds worth of distance run-\nYours is the earth and everything that's in it,\nAnd- which is more- you'll be a man my son.",
+    "author": "Rudyard Kipling",
+    "tag": []
+  },
+  {
+    "text": "It's better to be a warrior in a garden than a gardener in a war.",
+    "author": "Sun Tzu",
+    "tag": []
+  },
+  {
+    "text": "fortis fortuna adiuvat\n_fortune favors the bold_",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Never say never because limits,\nlike fears,\nare most often an illusion.",
+    "author": "Michael Jordan",
+    "tag": []
+  },
+  {
+    "text": "Reading maketh a full man;\nspeaking a ready man;\nwriting, an exact man.",
+    "author": "Francis Bacon",
+    "tag": []
+  },
+  {
+    "text": "Do the difficult things while they are easy\nand do the great things while they are small.\nA journey of a thousand miles must begin with a single step.",
+    "author": "Lao Tzu",
+    "tag": []
+  },
+  {
+    "text": "When boiled:\n* a carrot gets softer\n* an egg gets harder\n* and coffee changes the water itself",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The reasonable man adapts himself to the world;\nthe unreasonable one persists in trying to adapt the world to himself.\nTherefore, all progress depends on the unreasonable man.",
+    "author": "George Bernard Shaw",
+    "tag": []
+  },
+  {
+    "text": "You can easily judge the character of a man by how he treats those who can do nothing for him.",
+    "author": "Malcolm S. Forbes",
+    "tag": []
+  },
+  {
+    "text": "Where the spirit does not work with the hand there is no art.",
+    "author": "Leonardo da Vinci",
+    "tag": []
+  },
+  {
+    "text": "It is said that when Wesley and Whitefield were at odds on theology and ecclesiastical matters,\none of Wesley\u2019s adherents asked him,\n\u201cDo you think we shall see Mr. Whitefield in heaven?\u201d\n\u201cNo,\u201d he answered, \u201cI do not.\nI think he will be so near the Throne, and you and I so far away,\nthat we shall not get within sight of him.\u201d",
+    "author": "G. B. Wilcox",
+    "tag": []
+  },
+  {
+    "text": "He who knows not and knows not that he knows not is a fool; shun him.\nHe who knows not and knows that he knows not is ; teach him.\nHe who knows and knows not that he knows is asleep; wake him.\nHe who knows and knows that he knows is wise; follow him.",
+    "author": "Arabic Proverb",
+    "tag": []
+  },
+  {
+    "text": "The day soldiers stop bringing you their problems is the day you have stopped leading them.",
+    "author": "Colin Powell",
+    "tag": []
+  },
+  {
+    "text": "If they come for the innocent without stepping over your dead body, cursed be your religion and your life.",
+    "author": "Dorothy Day",
+    "tag": []
+  },
+  {
+    "text": "No Dad, no life\nKnow Dad, know life",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Give a man a fish and feed him for a day; teach a man to fish and feed him for a lifetime; teach him to teach others to fish - and you feed a nation.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Honor is the amount of personal risk one undertakes to manifest their beliefs.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Knowledge is a rumor until you have it in your body.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "If you want something you've never had, you have to do something you've never done.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Good enough isn't.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Whether you think you're good enough or not you're right.",
+    "author": "re: Henry Ford",
+    "tag": []
+  },
+  {
+    "text": "Leadership itself is amoral; its outcome depends on the heart of the leader.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "Perfer et obdura, dolor hic tibi proderit olim.\nBe patient and tough; this pain will help you someday.",
+    "author": "Ovid",
+    "tag": []
+  },
+  {
+    "text": "A sample size of you is not a population.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "God doesn't worry when we struggle with sin; He worries when we stop.",
+    "author": "Chris Murphy",
+    "tag": []
+  },
+  {
+    "text": "The stock market has predicted 7 of the last 2 recessions.",
+    "author": "reprise: George Soros",
+    "tag": []
+  },
+  {
+    "text": "Anyone can make a mistake, but the fool perseveres in error.",
+    "author": "Cicero",
+    "tag": []
+  },
+  {
+    "text": "The most improper job of any man, even saints (who at any rate were at least unwilling to take it on), is bossing other men.  Not one in a million is fit for it, and least of all those who seek the opportunity.",
+    "author": "J.R.R. Tolkien",
+    "tag": []
+  },
+  {
+    "text": "Any political hack can sell his soul to get ahead;  A truly skilled politician can gain on the sale of the souls of others.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Mon centre c\u00e8de, ma droite recule, situation excellente, j'attaque.",
+    "author": "Ferdinand Foch",
+    "tag": []
+  },
+  {
+    "text": "The desire for preeminence is the death knell of usefulness.",
+    "author": "Alistair Begg",
+    "tag": []
+  },
+  {
+    "text": "Whoever controls the past controls the present,\nwhoever controls the present controls the future.",
+    "author": "George Orwell",
+    "tag": []
+  },
+  {
+    "text": "A grandfather talking to his young grandson tells the boy he has two wolves inside of him, struggling with each other:\nThe first is the wolf of peace, love and kindness.\nThe other is the wolf of fear, greed and hatred.\n\"Which wolf will win, grandfather?\" asks the boy.\nThe grandfather replied,  \"Whichever one you feed.\"",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The person who says it cannot be done should not interrupt the person doing it.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Defeat is not failure but, rather, not to have tried.",
+    "author": "re: George Woodberry",
+    "tag": []
+  },
+  {
+    "text": "Child, \"Does God really watch me?\"\nPastor, \"He loves you so much He can't take His eyes off of you.\"",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Do what you can with what you have where you are.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "God puts maggots in our lives to clean the wounds.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "On a visit to the NASA space center, President Kennedy spoke to a man sweeping up in one of the buildings.\n\"What's your job here?\" asked Kennedy.\n\"Well Mr. President,\" the janitor replied, \"I'm helping to put a man on the moon\".",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A young fish swims up to an old fish, \"I'm looking for the ocean!\"\nThe old fish says, \"you're in it.\"\nThe young fish says, \"no, this is just water - I'm looking for the ocean!\"",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Read yourself full,\nSpeak yourself empty,\nWrite yourself clear;",
+    "author": "Allistair Begg",
+    "tag": []
+  },
+  {
+    "text": "It doesn\u2019t make sense to hire smart people and then tell them what to do; we hire smart people so they can tell us what to do.",
+    "author": "Steve Jobs",
+    "tag": []
+  },
+  {
+    "text": "Love is not an emotion. It is a policy.",
+    "author": "Hugh Bishop",
+    "tag": []
+  },
+  {
+    "text": "Democracy is the worst form of government, except for all the others.",
+    "author": "Winston Churchill",
+    "tag": []
+  },
+  {
+    "text": "On two occasions, I have been asked [by members of Parliament], \"Pray, Mr. Babbage, if you put into the machine wrong figures, will the right answers come out?\"\nI am not able to rightly apprehend the kind of confusion of ideas that could provoke such a question.",
+    "author": "Charles Babbage",
+    "tag": []
+  },
+  {
+    "text": "We are now gods but for the wisdom.",
+    "author": "Eric Weinstein",
+    "tag": []
+  },
+  {
+    "text": "A leader doesn't squeeze in what was left out, they draw out what was left in.",
+    "author": "unk",
+    "tag": []
+  },
+  {
+    "text": "Be uncommon amongst uncommon people.",
+    "author": "David Goggins",
+    "tag": []
+  },
+  {
+    "text": "Tenacity is the quality you need to overcome your stupendous lack of good judgment.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "When told that his vision would blow up Apple, Steve Jobs said, \"better we blow it up than someone else.\"",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Grace and glory differ very little;\nthe one is the seed, the other is the flower;\ngrace is glory militant, glory is grace triumphant.",
+    "author": "Thomas Brooks",
+    "tag": []
+  },
+  {
+    "text": "If you are neutral in situations of injustice, you have chosen the side of the oppressor.",
+    "author": "Desmond Tutu",
+    "tag": []
+  },
+  {
+    "text": "If an egg is broken by an outside force, life ends;\nIf an egg is broken by an inside force, life begins.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A man is one who has learned to operate under the authority of Jesus Christ while carrying out responsible and legitimate leadership within the sphere of influence that God has placed him.",
+    "author": "Tony Evans",
+    "tag": []
+  },
+  {
+    "text": "There are two hard problems in computing:\nautomatically synchronized and invalidating remote, caching storage,\nnaming things,\nand off-by-1 errors.",
+    "author": "re: Phil Karlton, Leon Bambrick",
+    "tag": []
+  },
+  {
+    "text": "The first step towards wisdom is to call things by their proper name.",
+    "author": "Confucius",
+    "tag": []
+  },
+  {
+    "text": "They know enough who know how to learn.",
+    "author": "Henry Brooks Adams",
+    "tag": []
+  },
+  {
+    "text": "switching elements are modeled by quantum mechanics described by differential equations whose behavior is captured by numerical approximations represented in computer programs executing on computers composed of switching elements",
+    "author": "Gerald Sussman",
+    "tag": []
+  },
+  {
+    "text": "\"Computer Science\" is not a science, and it's significance has little to do with computers.",
+    "author": "Marvin Minsky",
+    "tag": []
+  },
+  {
+    "text": "I think computer science, by and large, is still stuck in the Modern Age.",
+    "author": "Larry Wall",
+    "tag": []
+  },
+  {
+    "text": "In order to be great it isn't enough to be right - you must be great.",
+    "author": "M. L'Engle",
+    "tag": []
+  },
+  {
+    "text": "There are three components to success: simplify, simplify, simplify.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The first gulp from the glass of natural sciences will make you an Atheist,\nbut at the bottom of the glass, God is waiting for you.",
+    "author": "Werner Heisenberg",
+    "tag": []
+  },
+  {
+    "text": "Ex falso sequitur quodlibet.\n_from falsehood anything follows_.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "You feel things too deeply to bear them unless you can get them out of yourself through some sort of art.",
+    "author": "Madeleine L'Engle",
+    "tag": []
+  },
+  {
+    "text": "Upon review of the past year:\nI desire to confess that my unfaithfulness has been exceedingly great,\nmy sins still greater,\nGod's mercies greater than both.\nMy shortcomings and mis-doings,\nmy unbelief and want of love would sink me into the lowest hell,\nwas not Jesus my righteousness and my redeemer.",
+    "author": "Augustus Toplady",
+    "tag": []
+  },
+  {
+    "text": "There isn't much traffic on the extra mile.",
+    "author": "Henri Barber",
+    "tag": []
+  },
+  {
+    "text": "A design center should be equal parts monastery, pub, and sweatshop.",
+    "author": "Ilse Crawford",
+    "tag": []
+  },
+  {
+    "text": "Some have at first for wits, then poets passed,\nTurn\u2019d critics next, and proved plain fools at last.",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "A man convinced against his will is of the same opinion still.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The world is full of intellectual derelicts.",
+    "author": "Calvin Coolidge",
+    "tag": []
+  },
+  {
+    "text": "I don't skate to where the puck is, I skate to where the puck is going to be.",
+    "author": "Wayne Gretsky",
+    "tag": []
+  },
+  {
+    "text": "Who are the people most opposed to escapism?  Jailors!",
+    "author": "C.S. Lewis",
+    "tag": []
+  },
+  {
+    "text": "When two partners always agree, one of them is not necessary.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "There is a principle which:\nis a bar against all information,\nis a proof against all argument,\ncannot fail to keep man in everlasting ignorance;\ncondemnation before investigation.",
+    "author": "Edmund Spencer",
+    "tag": []
+  },
+  {
+    "text": "Evidence for the conspiracy is evidence for the conspiracy.\nEvidence against the conspiracy is evidence for the conspiracy.",
+    "author": "Stephen Novella",
+    "tag": []
+  },
+  {
+    "text": "In necessariis unitas,\nin dubiis libertas,\nin omnibus caritas.",
+    "author": "Rupertus Meldenius",
+    "tag": []
+  },
+  {
+    "text": "Searching something unsorted is inefficient,\nsorting something never searched is a waste of time.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "I am a revolutionary, so my son can be a farmer, so his son can be a poet.",
+    "author": "John Adams",
+    "tag": []
+  },
+  {
+    "text": "The Spartans do not ask how many the enemies are but where they are.",
+    "author": "Agis II",
+    "tag": []
+  },
+  {
+    "text": "Si vis pacem, para bellum.",
+    "author": "Plato via Publius Flavius",
+    "tag": []
+  },
+  {
+    "text": "Those people who will not be governed by God will be ruled by tyrants.",
+    "author": "William Penn",
+    "tag": []
+  },
+  {
+    "text": "Somewhere a True Believer is training to kill you.\nHe is training with minimal food or water, in austere conditions, day and night.\nThe only thing clean on him is his weapon.\nHe doesn't worry about what workout to do - his ruck weighs what it weighs, his run ends when the enemy stops chasing him.\nThis True Believer is not concerned about 'how hard it is,' he either wins or dies.\nHe doesn't go home at 17:00, he is home.\nHe knows only The Cause.",
+    "author": "Doc",
+    "tag": []
+  },
+  {
+    "text": "It is the soldier, not the reporter, who has given us Freedom of Press.\nIt is the soldier, not the poet, who has given us Freedom of Speech.\nIt is the soldier, not the campus organizer, who has given us the Freedom to Demonstrate.\nIt is the soldier, who salutes the flag, who serves beneath the flag, and whose coffin is draped by the flag that allows the protester to burn the flag.",
+    "author": "Father Dennis O'Brien; Chaplain, USN",
+    "tag": []
+  },
+  {
+    "text": "In the beginning of a change, the patriot is a scarce man, brave, hated, and scorned.\nWhen his cause succeeds however, the timid join him, for then it costs nothing to be a patriot.",
+    "author": "Mark Twain",
+    "tag": []
+  },
+  {
+    "text": "A superior operator uses his superior judgement to keep himself out of situations that would require his superior skills.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A human being should be able to change a diaper, plan an invasion, butcher a hog, conn a ship, design a building, write a sonnet, balance accounts, build a wall, set a bone, comfort the dying, take orders, give orders, cooperate, act alone, solve equations, analyze a new problem, pitch manure, program a computer, cook a tasty meal, fight efficiently, die gallantly.  Specialization is for insects.",
+    "author": "Robert A. Heinlein",
+    "tag": []
+  },
+  {
+    "text": "When the government's boot is on your throat, whether it is a left boot or a right boot is of no consequence.",
+    "author": "Gary Lloyd",
+    "tag": []
+  },
+  {
+    "text": "The difference between a warrior and an ordinary man is\na warrior sees everything as a challenge and an ordinary man sees it as a blessing or curse.",
+    "author": "Don Juan",
+    "tag": []
+  },
+  {
+    "text": "We do not rise to the occassion, we fall to the level of our training.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "We are what we repeatedly do.  Excellence, then, is not an act but a habit.",
+    "author": "Aristotle",
+    "tag": []
+  },
+  {
+    "text": "When you go home tell them of us and say, 'for their tomorrow we gave our today'.",
+    "author": "John Maxwell Edmonds",
+    "tag": []
+  },
+  {
+    "text": "The philosophy of the classroom today, will be the philosophy of the government tomorrow.",
+    "author": "Abraham Lincoln",
+    "tag": []
+  },
+  {
+    "text": "If there must be trouble, let it be in my day that my children may have peace.",
+    "author": "Thomas Paine",
+    "tag": []
+  },
+  {
+    "text": "We must, indeed, all hang together or, most assuredly, we shall all hang separately.",
+    "author": "Ben Franklin",
+    "tag": []
+  },
+  {
+    "text": "Let us speak courteously, deal fairly, and keep ourselves armed and ready.",
+    "author": "Theodore Roosevelt",
+    "tag": []
+  },
+  {
+    "text": "Food for the body is not enough.\nThere must be food for the soul.",
+    "author": "Dorothy Day",
+    "tag": []
+  },
+  {
+    "text": "Among the many misdeeds of the British rule in India, history will look upon the Act depriving a whole nation of arms, as the blackest.",
+    "author": "Mahatma Gandhi",
+    "tag": []
+  },
+  {
+    "text": "Even if you are a minority of one, the truth is the truth.",
+    "author": "Mahatma Gandhi",
+    "tag": []
+  },
+  {
+    "text": "Everything should be made as simple as possible, but not simpler.",
+    "author": "Albert Einstein",
+    "tag": []
+  },
+  {
+    "text": "The weak can never forgive.\nForgiveness is an attribute of the strong.",
+    "author": "Mahatma Gandhi",
+    "tag": []
+  },
+  {
+    "text": "The United States has sent many of its fine young men and women into great peril to fight for freedom beyond our borders.\nThe only amount of land we have ever asked for is enough to bury those that did not return.",
+    "author": "Colin Powell",
+    "tag": []
+  },
+  {
+    "text": "Teach your children the art of war, so that they may teach their children math and science, and their children can study art and literature.",
+    "author": "John Adams, 2nd President of the United States",
+    "tag": []
+  },
+  {
+    "text": "Those who sacrifice essential liberty for temporary safety are not deserving of either liberty or safety.",
+    "author": "Benjamin Franklin",
+    "tag": []
+  },
+  {
+    "text": "Nothing in Scripture depicts the Christian life as divided into sacred and secular parts.",
+    "author": "Dan Miller",
+    "tag": []
+  },
+  {
+    "text": "If your attack is going too well, you're probably walking into an ambush.",
+    "author": "Infantry Journal",
+    "tag": []
+  },
+  {
+    "text": "Divide et Impera\nDivide ut Regnes",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "There are four boxes to be used in the defense of liberty: soap, ballot, jury and ammo.\nPlease use in that order.",
+    "author": "Larry McDonald",
+    "tag": []
+  },
+  {
+    "text": "The democracy will cease to exist when you take away from those who are willing to work and give to those who would not.",
+    "author": "Thomas Jefferson",
+    "tag": []
+  },
+  {
+    "text": "The strongest reason for the people to retain the right to keep and bear arms is, as a last resort, to protect themselves against tyranny in government.",
+    "author": "Thomas Jefferson",
+    "tag": []
+  },
+  {
+    "text": "Drills teach principles.  They teach ideas.  They are the map, not the territory.",
+    "author": "MM",
+    "tag": []
+  },
+  {
+    "text": "Life should not be a journey to the grave with the intention of arriving safely in a pretty and well preserved body,\nbut rather to skid in broadside, thoroughly used up, totally worn out, and loudly proclaiming --WOW-- What a ride!",
+    "author": "Burke",
+    "tag": []
+  },
+  {
+    "text": "The beauty of the Second Amendment is that it will not be needed until they try to take it.",
+    "author": "Thomas Jefferson",
+    "tag": []
+  },
+  {
+    "text": "Gun Control: the theory that a woman found dead in an alley, raped, and strangled with her own pantyhose, is somehow morally superior to a woman explaining to police how her attacker got that fatal bullet wound.",
+    "author": "L. Neil Smith",
+    "tag": []
+  },
+  {
+    "text": "People sleep peacefully in their beds at night only because rough men stand ready to do violence on their behalf.",
+    "author": "George Orwell",
+    "tag": []
+  },
+  {
+    "text": "If you come expecting a fair fight, you are unprepared.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "To compel a man to furnish contributions of money for the propagation of opinions which he disbelieves and abhors, is sinful and tyrannical.",
+    "author": "Thomas Jefferson",
+    "tag": []
+  },
+  {
+    "text": "I am thus far a Quaker, that I would gladly argue with all the world to lay aside the use of arms and settle matters by negotiation,\nbut unless the whole will, the matter ends, and I take up my musket and thank Heaven He has put it in my power.",
+    "author": "Thomas Paine",
+    "tag": []
+  },
+  {
+    "text": "I am concerned for the security of our great nation, not so much because of any threat from without,\nbut because of the insidious forces working from within.",
+    "author": "General Douglas MacArthur",
+    "tag": []
+  },
+  {
+    "text": "Those who expect to reap the blessings of freedom must, like men, undergo the fatigue of supporting it.",
+    "author": "Thomas Paine",
+    "tag": []
+  },
+  {
+    "text": "Our freedom is not being destroyed by terrorists, but by ignorance, apathy and complacency.\nOur government schools are to blame...Our dumbing down is not accidental but a very well organized plan.",
+    "author": "Kelly McGinley",
+    "tag": []
+  },
+  {
+    "text": "If God does not punish America, He should apologize to Sodom & Gommorrah.",
+    "author": "Billy Graham",
+    "tag": []
+  },
+  {
+    "text": "Democracy is two wolves and a lamb discussing what's for dinner.\nLiberty is a well armed lamb willing to contest the majority decision.",
+    "author": "Benjamin Franklin",
+    "tag": []
+  },
+  {
+    "text": "Every normal man must be tempted at times to spit on his hands, hoist the black flag, and begin to slit throats.",
+    "author": "H.L. Mencken",
+    "tag": []
+  },
+  {
+    "text": "A man with a toothache cannot be in love.",
+    "author": "Shakespeare",
+    "tag": []
+  },
+  {
+    "text": "Ever tried.  Ever failed.  No matter.\nTry again.  Fail again.  Fail better.",
+    "author": "Samuel Beckett",
+    "tag": []
+  },
+  {
+    "text": "After each of our wars, there has always been a great hue and cry to the effect that...by removing the fire department, we will remove fires.",
+    "author": "George S. Patton",
+    "tag": []
+  },
+  {
+    "text": "I do not say that there will be no more wars; I devoutly hope that there will not, but I do say that the chances of avoiding future wars will be greatly enhanced if we are ready.",
+    "author": "George S. Patton",
+    "tag": []
+  },
+  {
+    "text": "A veteran - whether active duty, retired, national guard, or reserve - is someone who, at one point in his or her life, wrote a blank check made payable to The 'United States of America', for an amount of 'up to and including his life.'",
+    "author": "Author Unknown",
+    "tag": []
+  },
+  {
+    "text": "It is incumbent on every generation to pay its own debts as it goes.  A principle which if acted on would save one-half the wars of the world.",
+    "author": "Thomas Jefferson",
+    "tag": []
+  },
+  {
+    "text": "I predict future happiness for Americans if they can prevent the government from wasting the labors of the people under the pretense of taking care of them.",
+    "author": "Thomas Jefferson",
+    "tag": []
+  },
+  {
+    "text": "My reading of history convinces me that most bad government results from too much government.",
+    "author": "Thomas Jefferson",
+    "tag": []
+  },
+  {
+    "text": "I would never invade the United States.  There would be a gun behind every blade of grass.",
+    "author": "Isoroku Yamamoto",
+    "tag": []
+  },
+  {
+    "text": "Sell not virtue to purchase wealth, nor Liberty to purchase power.",
+    "author": "Benjamin Franklin",
+    "tag": []
+  },
+  {
+    "text": "If guns kill people, then:\npencils miss spel words,\ncars make people drive drunk,\nand spoons make people fat.",
+    "author": "GOOA",
+    "tag": []
+  },
+  {
+    "text": "My tone is a direct reflection of your attitude.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "An armed man is a citizen.  An unarmed man is a subject.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "A gun in the hand is better than a cop on the phone.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Gun control is not about guns; it's about control.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "If guns cause crime, then cameras cause pornography.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Free men do not have to ask permission to bear arms.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "If you don't know your rights you don't have any.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Guns only have two enemies: rust and liberals.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Know guns, know peace and safety.  No guns, no peace nor safety.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Assault is a type of behavior, not a type of hardware.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Criminals love gun control, it makes their jobs easier and safer.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The American Revolution wasn't about tea and taxes.  It was about taking guns!",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The pen is mightier than the sword, unless you are in a swordfight!",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Those who live by the sword have a fighting chance.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "My gun?  I'd rather have it and not need it than need it and not have it.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Firearm safety is a matter for education, not legislation.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "An armed society is a polite society.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "How can you praise freedom, and condemn that which gains and preserves it?",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "My wife and my gun: 'til death do us part.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "When they come for your guns, give them the ammo first!",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "When seconds count, the cops are just minutes away...",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Writing is not necessarily something to be ashamed of, but do it in private and wash your hands when you're done.",
+    "author": "Robert Heinlein",
+    "tag": []
+  },
+  {
+    "text": "A good speech should be like a woman's skirt; long enough to cover the subject and short enough to create interest.",
+    "author": "Winston Churchill",
+    "tag": []
+  },
+  {
+    "text": "I must not fear.  Fear is the mind-killer.  Fear is the little-death that brings total obliteration.  I will face my fear.  I will permit it to pass over me and through me.  And when it has gone past I will turn the inner eye to see its path.  Where the fear has gone there will be nothing.  Only I will remain.",
+    "author": "Bene Gesserit 'Litany Against Fear,'",
+    "tag": []
+  },
+  {
+    "text": "Night gathers, and now my watch begins.  It shall not end until my death.  I shall take no wife, hold no lands, father no children.  I shall wear no crowns and win no glory.  I shall live and die at my post.  I am the sword in the darkness.  I am the watcher on the walls.  I am the fire that burns against the cold, the light that brings the dawn, the horn that wakes the sleepers, the shield that guards the realms of men.  I pledge my life and honor to the Night's Watch, for this night and all the nights to come.",
+    "author": "George R.R. Martin, oath of the night's watch",
+    "tag": []
+  },
+  {
+    "text": "The crystal is the heart of the blade.\nThe heart is the crystal of the Jedi.\nThe Jedi is the crystal of the Force.\nThe Force is the blade of the heart.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Absorb what is useful, discard what is useless, and add what is uniquely your own.",
+    "author": "Bruce Lee",
+    "tag": []
+  },
+  {
+    "text": "\u1f66 \u03be\u03b5\u1fd6\u03bd', \u1f00\u03b3\u03b3\u03ad\u03bb\u03bb\u03b5\u03b9\u03bd \u039b\u03b1\u03ba\u03b5\u03b4\u03b1\u03b9\u03bc\u03bf\u03bd\u03af\u03bf\u03b9\u03c2 \u1f45\u03c4\u03b9 \u03c4\u1fc7\u03b4\u03b5 \u03ba\u03b5\u03af\u03bc\u03b5\u03b8\u03b1 \u03c4\u03bf\u1fd6\u03c2 \u03ba\u03b5\u03af\u03bd\u03c9\u03bd \u1fe5\u03ae\u03bc\u03b1\u03c3\u03b9 \u03c0\u03b5\u03b9\u03b8\u03cc\u03bc\u03b5\u03bd\u03bf\u03b9.",
+    "author": "the Cenotaph of Thermopylae",
+    "tag": []
+  },
+  {
+    "text": "Programs must be written for people to read, and only incidentally for machines to execute.",
+    "author": "H.Abelson & G.Sussman",
+    "tag": []
+  },
+  {
+    "text": "A common mistake people make when trying to design something completely foolproof is to underestimate the ingenuity of complete fools.",
+    "author": "D.Adams",
+    "tag": []
+  },
+  {
+    "text": "Don't worry about people stealing your ideas. If your ideas are any good, you'll have to ram them down people's throats.",
+    "author": "H. Aiken",
+    "tag": []
+  },
+  {
+    "text": "Good teaching is more a giving of the right questions than a giving of the right answers.",
+    "author": "J. Albers",
+    "tag": []
+  },
+  {
+    "text": "The absence of floods is drought, the impossibility of weeds is famine.",
+    "author": "The Monk, Diablo 3",
+    "tag": []
+  },
+  {
+    "text": "Scientists, like many others, are touched with awe at the order and complexity of nature.\nIndeed, many scientists are deeply religious.\nBut science and religion occupy two separate realms of human experience.\nDemanding that they be combined detracts from the glory of each.",
+    "author": "Bruce Alberts",
+    "tag": []
+  },
+  {
+    "text": "The most exciting phrase to hear in science - the one that heralds new discoveries - is not \"Eureka!\" but \"That's funny...\".",
+    "author": "Isaac Asimov",
+    "tag": []
+  },
+  {
+    "text": "A prudent question is one-half of wisdom.",
+    "author": "Francis Bacon",
+    "tag": []
+  },
+  {
+    "text": "The sole justification of teaching, of the school itself, is that the student comes out of it able to do something he could not do before.\nI say do and not know, because knowledge that doesn't lead to doing something new or doing something better is not knowledge at all.",
+    "author": "J. Barzun",
+    "tag": []
+  },
+  {
+    "text": "The key to performance is elegance, not batallions of special cases.",
+    "author": "J. Bently & D. McIlroy",
+    "tag": []
+  },
+  {
+    "text": "Coming together is a beginning; keeping together is progress; working together is success.",
+    "author": "Henry Ford",
+    "tag": []
+  },
+  {
+    "text": "If there is any one secret of success, it lies in the ability to get the other person\u2019s point of view and see things from that person\u2019s angle as well as from your own.",
+    "author": "Henry Ford",
+    "tag": []
+  },
+  {
+    "text": "Walking on water and developing software from a specification are easy if both are frozen.",
+    "author": "E. Berard",
+    "tag": []
+  },
+  {
+    "text": "Opposites are not contradictory but complementary.",
+    "author": "Neils Bohr",
+    "tag": []
+  },
+  {
+    "text": "About the only real power a CEO or Chairman has is giving motivational speeches, approving budgets, and moving names around on an org chart.",
+    "author": "Michael Hayden",
+    "tag": []
+  },
+  {
+    "text": "All programmers are playwrights and all computers are lousy actors.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Any programming problem can be solved by adding a level of indirection. (also see \"Any performance problem...\".)",
+    "author": "M. Haertel",
+    "tag": []
+  },
+  {
+    "text": "Experience is a poor teacher: it gives its tests before it teaches its lessons.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Given 8 hours to chop down a tree, spend 6 hours sharpening the axe.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "In theory, there is no difference between theory and practice, but not in practice.",
+    "author": "Yogi Berra",
+    "tag": []
+  },
+  {
+    "text": "If it doesn't fit, force it... If it breaks, it needed replacing anyway.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Measure twice, cut once.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "One boy is half a man, two boys is a half a boy, and three boys ain't no help at all.",
+    "author": "Lucius Currier",
+    "tag": []
+  },
+  {
+    "text": "One day a mother comes home from work and asks her son, \"What did you do today?\" The son replied, \"I taught our dog how to play the piano.\"\nThe mother, incredulous, asked, \"Our dog can play the piano?\",\nto which the son laughed and replied, \"Of course not mom.  I said that I taught him; I didn't say that he learned how.\"",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "The person who knows HOW will always have a job.\nThe person who knows WHY will always be his/her boss.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "There are 10 different kinds of people in the world: those who know binary and those who don't.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Time is an excellent teacher; but eventually it kills all its students.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "When a programming language is created that allows programmers to program in simple English, it will be discovered that programmers cannot speak English.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Perfectly written code is self-documenting.\nWhich is why all code should contain comments.",
+    "author": "@",
+    "tag": []
+  },
+  {
+    "text": "He who asks is a fool for five minutes; he who does not ask remains a fool forever.",
+    "author": null,
+    "tag": []
+  },
+  {
+    "text": "Life is painted on too big a canvas.",
+    "author": null,
+    "tag": []
+  }
+]


### PR DESCRIPTION
## Summary
- parse README quotes into JSON
- provide quotes dataset in `quotes.json`

## Testing
- `python3 - <<'PY'
import json, os
assert os.path.exists('quotes.json')
with open('quotes.json') as f:
    json.load(f)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684da9d2a694832795251a078689cc37