### PR TITLE
Fix gh-pages deployment authentication

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,4 +26,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: npm run deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use GH_TOKEN env var for gh-pages deployment

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0f01cd3a08327a91a2276b2bac71b