### PR TITLE
Add Dexie Cloud login and restrict editing to specific user

### DIFF
--- a/app/roles.json
+++ b/app/roles.json
@@ -1,0 +1,19 @@
+{
+  "default": {
+    "tables": {
+      "quotes": {
+        "read": true
+      }
+    }
+  },
+  "editor": {
+    "members": ["fingerskier@gmail.com"],
+    "tables": {
+      "quotes": {
+        "read": true,
+        "write": true
+      }
+    }
+  }
+}
+

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,15 +1,35 @@
 import './App.css'
 import QuotesList from './QuotesList'
+import { useState } from 'react'
+import { db } from './db'
 
 function App() {
+  const [tapCount, setTapCount] = useState(0)
+  const [canEdit, setCanEdit] = useState(false)
+
+  const handleHeaderTap = async () => {
+    const newCount = tapCount + 1
+    setTapCount(newCount)
+    if (newCount >= 10) {
+      setTapCount(0)
+      try {
+        await db.cloud.login()
+        const user = await (db as any).getCurrentUser()
+        setCanEdit(user?.email === 'fingerskier@gmail.com')
+      } catch (err) {
+        console.error('Login failed', err)
+      }
+    }
+  }
+
   return (
     <div>
-      <h1>
+      <h1 onClick={handleHeaderTap}>
         Manthra
         <br />
         <sub>considerable careful crafty compositions</sub>
       </h1>
-      <QuotesList />
+      <QuotesList canEdit={canEdit} />
     </div>
   )
 }

--- a/app/src/QuotesList.tsx
+++ b/app/src/QuotesList.tsx
@@ -17,8 +17,11 @@ interface Quote {
   tag: string[]
 }
 
+interface QuotesListProps {
+  canEdit: boolean
+}
 
-function QuotesList() {
+function QuotesList({ canEdit }: QuotesListProps) {
   const [quotes, setQuotes] = useState<Quote[]>(quotesData as Quote[])
   const [search, setSearch] = useState('')
   const [editIndex, setEditIndex] = useState<number | null>(null)
@@ -30,12 +33,16 @@ function QuotesList() {
   const [tags, setTags] = useState('')
 
 
-  const addQuote = ()=>{
-    setQuotes([...quotes, {
-      text: 'new quote',
-      author: 'new author',
-      tag: ['new', 'tag']
-    }])
+  const addQuote = () => {
+    if (!canEdit) return
+    setQuotes([
+      ...quotes,
+      {
+        text: 'new quote',
+        author: 'new author',
+        tag: ['new', 'tag']
+      }
+    ])
     setEditIndex(quotes.length)
     setText('new quote')
     setAuthor('new author')
@@ -68,7 +75,8 @@ function QuotesList() {
   }
 
 
-  const handleEditMode = (index: number) => ()=>{
+  const handleEditMode = (index: number) => () => {
+    if (!canEdit) return
     setEditIndex(index)
     setText(quotes[index].text)
     setAuthor(quotes[index].author ?? '')
@@ -132,10 +140,10 @@ function QuotesList() {
       onChange={(e) => setSearch(e.target.value)}
       style={{ marginBottom: '1rem' }}
     />
-    
-    {edited && <button onClick={saveFile}>Save</button>}
 
-    <button onClick={addQuote}>+</button>
+    {edited && canEdit && <button onClick={saveFile}>Save</button>}
+
+    {canEdit && <button onClick={addQuote}>+</button>}
 
     <div className={style.quotes}>
       {filtered.map((q, i) => (
@@ -164,7 +172,10 @@ function QuotesList() {
               <button onClick={handleChange}>done</button>
             </div>
           ) : (
-            <div onDoubleClick={handleEditMode(i)} className={style.quote}>
+            <div
+              onDoubleClick={canEdit ? handleEditMode(i) : undefined}
+              className={style.quote}
+            >
               <div>{q.text}</div>
               {q.author && (
                 <span className={style.author} style={{ fontStyle: 'italic' }}>


### PR DESCRIPTION
## Summary
- Trigger Dexie Cloud login after ten taps on the header and enable edits for the authenticated user
- Guard quote editing UI behind a `canEdit` flag
- Define roles so only `fingerskier@gmail.com` has write access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c19efc0bd48327a11af3d536b430ca