### PR TITLE
Allow editors to log in and manage quotes

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,15 +1,36 @@
+import { useEffect, useRef, useState } from 'react';
+import type { DBRealmRole } from 'dexie-cloud-common';
 import './App.css';
 import QuotesList from './QuotesList';
+import { db } from './db';
 
 function App() {
+  const clicks = useRef(0);
+  const [canEdit, setCanEdit] = useState(false);
+
+  useEffect(() => {
+    const sub = db.cloud.roles.subscribe((roles: Record<string, DBRealmRole>) => {
+      setCanEdit(!!roles.editor);
+    });
+    return () => sub.unsubscribe();
+  }, []);
+
+  const handleHeaderClick = () => {
+    clicks.current += 1;
+    if (clicks.current === 10) {
+      db.cloud.login();
+      clicks.current = 0;
+    }
+  };
+
   return (
     <div>
-      <h1>
+      <h1 onClick={handleHeaderClick}>
         Manthra
         <br />
         <sub>considerable careful crafty compositions</sub>
       </h1>
-      <QuotesList />
+      <QuotesList editable={canEdit} />
     </div>
   );
 }

--- a/app/src/QuotesList.tsx
+++ b/app/src/QuotesList.tsx
@@ -1,13 +1,20 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { liveQuery } from 'dexie';
 import fuzzy from 'fuzzy';
 import { db, type Quote } from './db';
 import style from './Quotes.module.css';
 
-function QuotesList() {
+interface Props {
+  editable: boolean;
+}
+
+function QuotesList({ editable }: Props) {
   const [quotes, setQuotes] = useState<Quote[]>([]);
   const [search, setSearch] = useState('');
   const [filtered, setFiltered] = useState<Quote[]>([]);
+  const [newText, setNewText] = useState('');
+  const [newAuthor, setNewAuthor] = useState('');
+  const [newTags, setNewTags] = useState('');
 
   useEffect(() => {
     const sub = liveQuery(() => db.quotes.toArray()).subscribe({
@@ -28,6 +35,28 @@ function QuotesList() {
     setFiltered(results.map((r) => r.original));
   }, [search, quotes]);
 
+  const addQuote = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!newText.trim()) return;
+    await db.quotes.add({
+      id: crypto.randomUUID(),
+      text: newText,
+      author: newAuthor.trim() || null,
+      tag:
+        newTags
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean) ?? [],
+    });
+    setNewText('');
+    setNewAuthor('');
+    setNewTags('');
+  };
+
+  const updateQuote = (id: string, changes: Partial<Quote>) => {
+    db.quotes.update(id, changes);
+  };
+
   return (
     <>
       <input
@@ -36,15 +65,69 @@ function QuotesList() {
         onChange={(e) => setSearch(e.target.value)}
         style={{ marginBottom: '1rem' }}
       />
+      {editable && (
+        <form onSubmit={addQuote} style={{ marginBottom: '1rem' }}>
+          <textarea
+            placeholder="quote"
+            value={newText}
+            onChange={(e) => setNewText(e.target.value)}
+            style={{ display: 'block', width: '100%' }}
+          />
+          <input
+            placeholder="author"
+            value={newAuthor}
+            onChange={(e) => setNewAuthor(e.target.value)}
+            style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
+          />
+          <input
+            placeholder="tags (comma separated)"
+            value={newTags}
+            onChange={(e) => setNewTags(e.target.value)}
+            style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
+          />
+          <button type="submit" style={{ marginTop: '0.5rem' }}>
+            Add Quote
+          </button>
+        </form>
+      )}
       <div className={style.quotes}>
         {filtered.map((q, i) => (
           <div key={q.id ?? i} style={{ marginBottom: '1rem' }}>
             <div className={style.quote}>
-              <div>{q.text}</div>
-              {q.author && (
-                <span className={style.author} style={{ fontStyle: 'italic' }}>
-                  {q.author}
-                </span>
+              {editable ? (
+                <>
+                  <textarea
+                    value={q.text}
+                    onChange={(e) => updateQuote(q.id!, { text: e.target.value })}
+                    style={{ display: 'block', width: '100%' }}
+                  />
+                  <input
+                    value={q.author ?? ''}
+                    onChange={(e) => updateQuote(q.id!, { author: e.target.value })}
+                    style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
+                  />
+                  <input
+                    value={q.tag.join(', ')}
+                    onChange={(e) =>
+                      updateQuote(q.id!, {
+                        tag: e.target.value
+                          .split(',')
+                          .map((t) => t.trim())
+                          .filter(Boolean),
+                      })
+                    }
+                    style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
+                  />
+                </>
+              ) : (
+                <>
+                  <div>{q.text}</div>
+                  {q.author && (
+                    <span className={style.author} style={{ fontStyle: 'italic' }}>
+                      {q.author}
+                    </span>
+                  )}
+                </>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Trigger Dexie Cloud login after 10 header clicks
- Enable role-based inline editing and adding of quotes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1aa219c308327a0de08497d555013