### PR TITLE
fix: ensure dexie cloud configured

### DIFF
--- a/app/src/QuotesList.tsx
+++ b/app/src/QuotesList.tsx
@@ -65,9 +65,6 @@ function QuotesList({ editable }: Props) {
         onChange={(e) => setSearch(e.target.value)}
         style={{ marginBottom: '1rem' }}
       />
-<<<<<<< HEAD
-      
-=======
       {editable && (
         <form onSubmit={addQuote} style={{ marginBottom: '1rem' }}>
           <textarea
@@ -93,7 +90,6 @@ function QuotesList({ editable }: Props) {
           </button>
         </form>
       )}
->>>>>>> a7e96d8bdccdd998f62c8deeaff5ec30a7255174
       <div className={style.quotes}>
         {filtered.map((q, i) => (
           <div key={q.id ?? i} style={{ marginBottom: '1rem' }}>

--- a/app/src/db.ts
+++ b/app/src/db.ts
@@ -1,5 +1,6 @@
 import Dexie, { type Table } from 'dexie';
 import dexieCloud from 'dexie-cloud-addon';
+import cloudConfig from '../dexie-cloud.json';
 
 export interface Quote {
   id?: string;
@@ -21,12 +22,15 @@ export class ManthraDB extends Dexie {
       quotes: 'id, text, author, tag',
     });
 
-    const databaseUrl = import.meta.env?.VITE_DEXIE_CLOUD_URL;
+    const databaseUrl =
+      import.meta.env?.VITE_DEXIE_CLOUD_URL ?? cloudConfig.dbUrl;
 
     if (databaseUrl) {
       this.cloud.configure({
         databaseUrl,
       });
+    } else {
+      console.warn('Dexie Cloud database URL not configured');
     }
   }
 }

--- a/app/tsconfig.app.json
+++ b/app/tsconfig.app.json
@@ -6,6 +6,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "resolveJsonModule": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- load Dexie Cloud URL from `dexie-cloud.json` as fallback for login
- enable JSON module imports in TypeScript config
- clean up merge markers in `QuotesList`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1acce4fd0832780e62747e943e131