### PR TITLE
feat: show login icon and sync quotes

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,12 +7,25 @@ import { db } from './db';
 function App() {
   const clicks = useRef(0);
   const [canEdit, setCanEdit] = useState(false);
+  const [loggedIn, setLoggedIn] = useState(false);
 
   useEffect(() => {
-    const sub = db.cloud.roles.subscribe((roles: Record<string, DBRealmRole>) => {
-      setCanEdit(!!roles.editor);
+    const rolesSub = db.cloud.roles.subscribe(
+      (roles: Record<string, DBRealmRole>) => {
+        setCanEdit(!!roles.editor);
+      },
+    );
+    const userSub = db.cloud.currentUser.subscribe((user) => {
+      setLoggedIn(user.isLoggedIn);
+      if (user.isLoggedIn) {
+        db.cloud.sync().catch((err) => console.error('Sync failed', err));
+      }
     });
-    return () => sub.unsubscribe();
+    db.cloud.sync().catch((err) => console.error('Sync failed', err));
+    return () => {
+      rolesSub.unsubscribe();
+      userSub.unsubscribe();
+    };
   }, []);
 
   const handleHeaderClick = () => {
@@ -26,7 +39,7 @@ function App() {
   return (
     <div>
       <h1 onClick={handleHeaderClick}>
-        Manthra
+        Manthra {loggedIn && <span aria-label="logged in">👤</span>}
         <br />
         <sub>considerable careful crafty compositions</sub>
       </h1>


### PR DESCRIPTION
## Summary
- show login status with user icon in header
- trigger Dexie Cloud sync to load imported quotes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1c7769d58832782229590b4205fc0