### PR TITLE
Fix Dexie Cloud sync

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,7 +16,7 @@ function App() {
       },
     );
     const userSub = db.cloud.currentUser.subscribe((user) => {
-      setLoggedIn(user.isLoggedIn);
+      setLoggedIn(!!user.isLoggedIn);
       if (user.isLoggedIn) {
         db.cloud.sync().catch((err) => console.error('Sync failed', err));
       }

--- a/app/src/db.ts
+++ b/app/src/db.ts
@@ -23,12 +23,14 @@ export class ManthraDB extends Dexie {
     });
 
     const databaseUrl =
-      import.meta.env?.VITE_DEXIE_CLOUD_URL ?? cloudConfig.dbUrl;
+      import.meta.env?.VITE_DEXIE_CLOUD_URL ?? cloudConfig.databaseUrl ?? cloudConfig.dbUrl;
 
     if (databaseUrl) {
       this.cloud.configure({
         databaseUrl,
       });
+
+      void this.cloud.sync();
     } else {
       console.warn('Dexie Cloud database URL not configured');
     }
@@ -36,4 +38,10 @@ export class ManthraDB extends Dexie {
 }
 
 export const db = new ManthraDB();
-window.db = db
+window.db = db;
+
+declare global {
+  interface Window {
+    db: ManthraDB;
+  }
+}


### PR DESCRIPTION
## Summary
- configure Dexie Cloud using environment or config file and start sync on init
- type global `window.db` reference
- coerce login state to boolean to satisfy TypeScript

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1f5e12a248327bd9ea1fab9d0943b