### PR TITLE
Default new quotes to public realm

### DIFF
--- a/app/src/QuotesList.tsx
+++ b/app/src/QuotesList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type FormEvent } from 'react';
 import { liveQuery } from 'dexie';
 import fuzzy from 'fuzzy';
-import { db, type Quote } from './db';
+import { db, type Quote, PUBLIC_REALM_ID } from './db';
 import style from './Quotes.module.css';
 
 interface Props {
@@ -49,6 +49,7 @@ function QuotesList({ editable, loggedIn }: Props) {
           .split(',')
           .map((t) => t.trim())
           .filter(Boolean) ?? [],
+      realmId: PUBLIC_REALM_ID,
     });
     setNewText('');
     setNewAuthor('');

--- a/app/src/db.ts
+++ b/app/src/db.ts
@@ -2,11 +2,15 @@ import Dexie, { type Table } from 'dexie';
 import dexieCloud from 'dexie-cloud-addon';
 import cloudConfig from '../dexie-cloud.json';
 
+export const PUBLIC_REALM_ID = 'rlm-public';
+
 export interface Quote {
   id?: string;
   text: string;
   author: string | null;
   tag: string[];
+  /** Dexie Cloud realm identifier */
+  realmId?: string;
 }
 
 export class ManthraDB extends Dexie {


### PR DESCRIPTION
## Summary
- Export `PUBLIC_REALM_ID` and optional `realmId` field on quotes
- Assign new quotes to the public realm automatically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3044cc0208327b34387718d14eb47