### PR TITLE
Add edit button for quotes

### DIFF
--- a/app/src/QuotesList.tsx
+++ b/app/src/QuotesList.tsx
@@ -130,6 +130,20 @@ function QuotesList({ editable, loggedIn }: Props) {
               }}
               tabIndex={-1}
             >
+              {editable && loggedIn && editingId !== q.id && (
+                <button
+                  aria-label="edit quote"
+                  onClick={() => setEditingId(q.id!)}
+                  style={{
+                    float: 'right',
+                    cursor: 'pointer',
+                    background: 'transparent',
+                    border: 'none',
+                  }}
+                >
+                  ✏️
+                </button>
+              )}
               {editable && editingId === q.id ? (
                 <>
                   <textarea


### PR DESCRIPTION
## Summary
- add pencil icon button so logged-in editors can start editing quotes without double-clicking

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c308e76acc83279265192efbbe6068