### PR TITLE
refactor quotes editor and styles

### DIFF
--- a/app/src/QuoteEditor.tsx
+++ b/app/src/QuoteEditor.tsx
@@ -1,0 +1,38 @@
+import { type Quote } from './db';
+import style from './Quotes.module.css';
+
+interface Props {
+  quote: Quote;
+  onChange: (changes: Partial<Quote>) => void;
+}
+
+function QuoteEditor({ quote, onChange }: Props) {
+  return (
+    <>
+      <textarea
+        value={quote.text}
+        onChange={(e) => onChange({ text: e.target.value })}
+        className={style.fullWidth}
+      />
+      <input
+        value={quote.author ?? ''}
+        onChange={(e) => onChange({ author: e.target.value })}
+        className={`${style.fullWidth} ${style.mtHalf}`}
+      />
+      <input
+        value={quote.tag.join(', ')}
+        onChange={(e) =>
+          onChange({
+            tag: e.target.value
+              .split(',')
+              .map((t) => t.trim())
+              .filter(Boolean),
+          })
+        }
+        className={`${style.fullWidth} ${style.mtHalf}`}
+      />
+    </>
+  );
+}
+
+export default QuoteEditor;

--- a/app/src/Quotes.module.css
+++ b/app/src/Quotes.module.css
@@ -20,3 +20,40 @@
   padding: 0.5rem;
   border-radius: 50%;
 }
+
+.searchInput {
+  margin-bottom: 1rem;
+}
+
+.addButton {
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.addForm {
+  margin-bottom: 1rem;
+}
+
+.fullWidth {
+  display: block;
+  width: 100%;
+}
+
+.mtHalf {
+  margin-top: 0.5rem;
+}
+
+.mlHalf {
+  margin-left: 0.5rem;
+}
+
+.quoteWrapper {
+  margin-bottom: 1rem;
+}
+
+.editButton {
+  float: right;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+}

--- a/app/src/QuotesList.tsx
+++ b/app/src/QuotesList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type FormEvent, type FocusEvent } from 'react';
 import { liveQuery } from 'dexie';
 import fuzzy from 'fuzzy';
 import { db, type Quote, PUBLIC_REALM_ID } from './db';
+import QuoteEditor from './QuoteEditor';
 import style from './Quotes.module.css';
 
 interface Props {
@@ -66,12 +67,12 @@ function QuotesList({ loggedIn }: Props) {
         placeholder="search"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        style={{ marginBottom: '1rem' }}
+        className={style.searchInput}
       />
       {loggedIn && !adding && (
         <button
           onClick={() => setAdding(true)}
-          style={{ display: 'block', marginBottom: '1rem' }}
+          className={style.addButton}
         >
           Add
         </button>
@@ -82,33 +83,33 @@ function QuotesList({ loggedIn }: Props) {
             addQuote(e);
             setAdding(false);
           }}
-          style={{ marginBottom: '1rem' }}
+          className={style.addForm}
         >
           <textarea
             placeholder="quote"
             value={newText}
             onChange={(e) => setNewText(e.target.value)}
-            style={{ display: 'block', width: '100%' }}
+            className={style.fullWidth}
           />
           <input
             placeholder="author"
             value={newAuthor}
             onChange={(e) => setNewAuthor(e.target.value)}
-            style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
+            className={`${style.fullWidth} ${style.mtHalf}`}
           />
           <input
             placeholder="tags (comma separated)"
             value={newTags}
             onChange={(e) => setNewTags(e.target.value)}
-            style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
+            className={`${style.fullWidth} ${style.mtHalf}`}
           />
-          <button type="submit" style={{ marginTop: '0.5rem' }}>
+          <button type="submit" className={style.mtHalf}>
             Add Quote
           </button>
           <button
             type="button"
             onClick={() => setAdding(false)}
-            style={{ marginTop: '0.5rem', marginLeft: '0.5rem' }}
+            className={`${style.mtHalf} ${style.mlHalf}`}
           >
             Cancel
           </button>
@@ -116,7 +117,7 @@ function QuotesList({ loggedIn }: Props) {
       )}
       <div className={style.quotes}>
         {filtered.map((q, i) => (
-          <div key={q.id ?? i} style={{ marginBottom: '1rem' }}>
+          <div key={q.id ?? i} className={style.quoteWrapper}>
             <div
               className={style.quote}
               onDoubleClick={() => {
@@ -133,48 +134,21 @@ function QuotesList({ loggedIn }: Props) {
                 <button
                   aria-label="edit quote"
                   onClick={() => setEditingId(q.id!)}
-                  style={{
-                    float: 'right',
-                    cursor: 'pointer',
-                    background: 'transparent',
-                    border: 'none',
-                  }}
+                  className={style.editButton}
                 >
                   ✏️
                 </button>
               )}
               {loggedIn && editingId === q.id ? (
-                <>
-                  <textarea
-                    value={q.text}
-                    onChange={(e) => updateQuote(q.id!, { text: e.target.value })}
-                    style={{ display: 'block', width: '100%' }}
-                  />
-                  <input
-                    value={q.author ?? ''}
-                    onChange={(e) => updateQuote(q.id!, { author: e.target.value })}
-                    style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
-                  />
-                  <input
-                    value={q.tag.join(', ')}
-                    onChange={(e) =>
-                      updateQuote(q.id!, {
-                        tag: e.target.value
-                          .split(',')
-                          .map((t) => t.trim())
-                          .filter(Boolean),
-                      })
-                    }
-                    style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
-                  />
-                </>
+                <QuoteEditor
+                  quote={q}
+                  onChange={(changes) => updateQuote(q.id!, changes)}
+                />
               ) : (
                 <>
                   <div>{q.text}</div>
                   {q.author && (
-                    <span className={style.author} style={{ fontStyle: 'italic' }}>
-                      {q.author}
-                    </span>
+                    <span className={style.author}>{q.author}</span>
                   )}
                 </>
               )}


### PR DESCRIPTION
## Summary
- extract quote editor into its own component
- replace inline quote styles with CSS module classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c30fda599c832795b83ebeceba5a65