### PR TITLE
Let Dexie Cloud handle quote IDs

### DIFF
--- a/app/quotes.json
+++ b/app/quotes.json
@@ -3,7 +3,6 @@
     "rlm-public": {
       "quotes": [
         {
-          "id": "5dfed19d-9d21-4c3b-833f-13d09a3aa6cc",
           "text": "You want strength? discipline builds it.\nYou want peace? discipline protects it.\nYou want respect? discipline earns it.",
           "author": "Khabib Nurmagomedov",
           "tag": [
@@ -12,7 +11,6 @@
           ]
         },
         {
-          "id": "5ac8b481-e8e2-40b0-b7b7-8722b722da22",
           "text": "Never be afraid to trust an unknown future to a known God.",
           "author": "Corrie Ten Boom",
           "tag": [
@@ -21,7 +19,6 @@
           ]
         },
         {
-          "id": "743f37c1-2ea0-4d66-8c0d-c23fabc52da7",
           "text": "One should never forget that by actually perfecting one piece one gains and learns more than by starting or half-finishing a dozen.",
           "author": "Johannes Brahms",
           "tag": [
@@ -34,7 +31,6 @@
           ]
         },
         {
-          "id": "bc63db83-e729-4226-86f6-846d6e16791b",
           "text": "Fruitless is inspiration without craftsmanship, is intellect without study, is talent without work.",
           "author": "Johannes Brahms",
           "tag": [
@@ -46,7 +42,6 @@
           ]
         },
         {
-          "id": "0bfe73f0-f10b-4d92-9cc2-d95ef7fa231e",
           "text": "In my study I can lay my hand on the Bible in the pitch dark. All truly inspired ideas come from God. The powers from which all truly great composers like Mozart, Schubert, Bach and Beethoven drew their inspirations is the same power that enabled Jesus to do his miracles.",
           "author": "Johannes Brahms",
           "tag": [
@@ -57,7 +52,6 @@
           ]
         },
         {
-          "id": "ac1a2f68-afa7-49de-8c38-812fdf3f9c4e",
           "text": "If there is anyone here whom I have not insulted, I beg his pardon.",
           "author": "Johannes Brahms",
           "tag": [
@@ -65,7 +59,6 @@
           ]
         },
         {
-          "id": "bfdfcb06-771f-4509-a0b9-f48792e381b1",
           "text": "some people can read \"War and Peace\" and come away thinking it's a simple adventure story. Others can read the ingredients on a chewing gum wrapper and unlock the secrets of the universe.",
           "author": "Lex Luthor",
           "tag": [
@@ -73,7 +66,6 @@
           ]
         },
         {
-          "id": "1ace3996-6433-42b6-8baa-aee9ada82522",
           "text": "Intellect is not the amount of knowledge created\nbut the percent of possibilities that weren't.",
           "author": "",
           "tag": [
@@ -81,7 +73,6 @@
           ]
         },
         {
-          "id": "4188a052-605e-49ee-84cd-9ae42fc55132",
           "text": "Storms reveal how skilled a sailor you are.",
           "author": "",
           "tag": [
@@ -89,7 +80,6 @@
           ]
         },
         {
-          "id": "2bbc1dbb-5342-4289-b042-48482785c747",
           "text": "The ground is even at the foot of the cross.",
           "author": "N.T. Wright",
           "tag": [
@@ -97,7 +87,6 @@
           ]
         },
         {
-          "id": "a8304cfc-5058-43da-a4aa-da93b47c67ac",
           "text": "History ended 50 years ago.\nEverything since then is politics.",
           "author": "W.Currier",
           "tag": [
@@ -105,439 +94,366 @@
           ]
         },
         {
-          "id": "f2f64e15-38fe-4728-b8b8-c90281f13390",
           "text": "If you're asked to be a hero, be a hero;\nIf you're not asked to be a hero, be a hero.",
           "author": null,
           "tag": []
         },
         {
-          "id": "157af5c7-661e-4fc4-b0e8-2edb70b3b02f",
           "text": "Some people, when you give them enough rope make a lasso;\nother people make a noose.",
           "author": null,
           "tag": []
         },
         {
-          "id": "80ffcbb8-6011-4f68-9638-f1d0e61c8855",
           "text": "Magic is science we don't understand.",
           "author": "",
           "tag": []
         },
         {
-          "id": "064836a8-0caf-4c53-ba98-97457a64a200",
           "text": "No battle plan survives first contact.",
           "author": "Helmuth von Moltke",
           "tag": []
         },
         {
-          "id": "0a706e76-609f-4015-b45c-b08ba3f04539",
           "text": "We must daily make a raid on the inarticulate.",
           "author": "T.S. Eliot",
           "tag": []
         },
         {
-          "id": "f3923ad5-773b-4530-baf3-23956a92e0ca",
           "text": "The answer to the question, \"can machines can think?\" is the same as the answer to \"can submarines can swim?\"",
           "author": null,
           "tag": []
         },
         {
-          "id": "896022e7-9847-4fcc-8c01-f6a972babc8c",
           "text": "You blame a final symbolism as the root of your difficulties.",
           "author": null,
           "tag": []
         },
         {
-          "id": "8c3a87a4-be72-4097-8806-6c94e4ef6e2a",
           "text": "You're either following someone or you're following anyone.",
           "author": null,
           "tag": []
         },
         {
-          "id": "217b09b0-51a3-49ab-9ff9-ee839f09175f",
           "text": "I'm only lazy when I have to be.",
           "author": null,
           "tag": []
         },
         {
-          "id": "97826b45-c281-42c5-9993-ab3839502be0",
           "text": "I can explain it to you but I can't understand it for you.",
           "author": null,
           "tag": []
         },
         {
-          "id": "70a94cfe-8bf0-4c16-b678-cc409fe75a26",
           "text": "I love synonym rolls, just like grammar used to make.",
           "author": null,
           "tag": []
         },
         {
-          "id": "386606bb-f32b-49f7-b000-819ba8453c23",
           "text": "Tolerance will reach such a level that intelligent people will be banned from thinking so as not to offend imbeciles.",
           "author": "Dostoievski",
           "tag": []
         },
         {
-          "id": "3bc5bbc8-1cc1-48b2-bcbc-ee8ca25a6478",
           "text": "Intelligence is the creature's ability to use what wits it has.",
           "author": null,
           "tag": []
         },
         {
-          "id": "a182244c-fe97-4012-9f74-4dabe29da1d0",
           "text": "Without craftsmanship inspiration is a mere reed shaken in the wind.",
           "author": "Johannes Brahms",
           "tag": []
         },
         {
-          "id": "e6254ada-fa79-4272-81ba-214a26293d51",
           "text": "There are two kinds of pain in this world: pain that hurts and pain that alters.",
           "author": null,
           "tag": []
         },
         {
-          "id": "eff6c327-5e4d-4d89-b69b-1fcb639a05fc",
           "text": "The two most important days in your life are the day you were born and the day you find out why.",
           "author": "Mark Twain",
           "tag": []
         },
         {
-          "id": "05dc65ef-6f77-4f17-bdae-7580207865d1",
           "text": "No amount of money ever bought a second of time.",
           "author": null,
           "tag": []
         },
         {
-          "id": "fc50ae6c-7a29-4d02-884d-ca15db3ee21b",
           "text": "Repetition has been accepted as a substitute for evidence.",
           "author": "Thomas Sowell",
           "tag": []
         },
         {
-          "id": "3ba1fc90-3383-45e1-b99f-8e1fb69cb856",
           "text": "The goalie always makes the last mistake.",
           "author": "JY",
           "tag": []
         },
         {
-          "id": "e8f88602-002a-4148-8dd4-714d4e2b1b81",
           "text": "The person who doesn't read had no advantage over the person who can't.",
           "author": "Mark Twain",
           "tag": []
         },
         {
-          "id": "8ae50737-7362-41a0-a256-18fb45525b28",
           "text": "For God so loved the wordi that He did not send a committee.",
           "author": "2 Hesitations 5:6",
           "tag": []
         },
         {
-          "id": "76b49c91-fe63-4704-9340-75f8eaa33a4f",
           "text": "I finally figured out what's wrong with my brain:\nthere's nothing right on the left side,\nand nothing left on the right side.",
           "author": "A.Currier",
           "tag": []
         },
         {
-          "id": "9bf2945f-a444-4c1e-b20b-2a27b5926dd8",
           "text": "They who have put out the people's eyes reproach them of their blindness.",
           "author": "John Milton",
           "tag": []
         },
         {
-          "id": "e2dc734a-359b-43e5-9f4c-3180e973a8b9",
           "text": "The Lord delights to hang great weights on apparently slender wires.",
           "author": "Jowett",
           "tag": []
         },
         {
-          "id": "a89fd641-02da-4f13-9039-0679f6800f0e",
           "text": "Humility is the ladder from which all else is grasped.",
           "author": null,
           "tag": []
         },
         {
-          "id": "4fccc59c-f9da-4fe0-bb39-974aecb79765",
           "text": "When you board the wrong train,\nit doesn't do any good to run the opposite direction.",
           "author": "Dietrich Bonhoeffer",
           "tag": []
         },
         {
-          "id": "5b0e41dc-1a7f-414c-ad38-42cf2f1df414",
           "text": "It’s such a fine line between stupid and clever.",
           "author": "David St. Hubbins",
           "tag": []
         },
         {
-          "id": "55dd29ce-c6ae-4129-99a4-f1824bacb783",
           "text": "Jesus taught 1st century Jews; any relevance of that to us must start with them.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "e0bfa6ac-b7b2-4cf3-bf5f-49dc132e8cb4",
           "text": "A great, a good, and a right mind is a kind of divinity lodged in flesh, and may be the blessing of a slave as well as of a prince.",
           "author": "Seneca the Younger",
           "tag": []
         },
         {
-          "id": "1839fab3-01f0-4927-838a-2ed1a08b0775",
           "text": "Art without a transcendental nature always seems less primitive.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "b06b4442-d726-4bb3-8002-46a02c1ceb5c",
           "text": "Whoever, therefore, thinks that he understands the Holy Scriptures, or any part of them, but puts such an interpretation upon them as does not tend to build up this twofold love of God and our neighbor, does not yet understand them as he ought.",
           "author": "Augustine",
           "tag": []
         },
         {
-          "id": "6adbfd8f-d58b-4144-82b1-0f947aa4a26d",
           "text": "Medicine is the art of amusing the patient while nature heals the injury.",
           "author": "Voltaire",
           "tag": []
         },
         {
-          "id": "dbeb33f0-dbfd-4470-a4c0-ff5314788cb7",
           "text": "Young conservatives have no heart,\nold liberals have no brain.",
           "author": "WBC",
           "tag": []
         },
         {
-          "id": "8270b281-a311-49c9-9d5f-8b2f0c85293d",
           "text": "The mark of a trained mind is the ability to entertain ideas without accepting them.",
           "author": "Aritstotle",
           "tag": []
         },
         {
-          "id": "45d0e5d6-d77d-4106-beda-525eabc1beea",
           "text": "Confidence is the food of the wise but the liquor of fools.",
           "author": null,
           "tag": []
         },
         {
-          "id": "2b99dacc-4139-4c52-ae27-2fc0174c44bd",
           "text": "We should have more reverence for Scripture than to allow ourselves to transfigure its sense so freely.",
           "author": "John Calvin",
           "tag": []
         },
         {
-          "id": "71a1e794-309a-4088-a5d2-2ba149a4bfd9",
           "text": "You don't get stronger in the gym,\nyou get stronger because of the gym.",
           "author": null,
           "tag": []
         },
         {
-          "id": "59f59c9d-e1c6-4c68-9af8-50a38335bf67",
           "text": "If life gets too hard to stand, kneel.",
           "author": "Gordon B. Hinckley",
           "tag": []
         },
         {
-          "id": "ade7377d-ed2c-4165-9df8-0721bb584a9f",
           "text": "That is the law according to the rules.",
           "author": "Dwight Schrute",
           "tag": []
         },
         {
-          "id": "d4319a84-0be4-43bf-a125-21b766684e3a",
           "text": "While most of us go through life afraid that people will think too little of us,\n[the apostle] Paul went through life afraid people would think too much of him.",
           "author": "D. A. Carson",
           "tag": []
         },
         {
-          "id": "c5122896-5baa-4452-8aaf-5a3a42330f37",
           "text": "Not choosing is choosing the not.",
           "author": null,
           "tag": []
         },
         {
-          "id": "27ec0fe9-5b0e-45a0-8710-fa71a3569c79",
           "text": "Faith is a recipe from God and you are the secret ingredient.",
           "author": null,
           "tag": []
         },
         {
-          "id": "9ff60445-9be0-4e52-b64d-14a061c143d4",
           "text": "Encountering the gospel is like getting hit by an 18 wheeler- you're gonna be different.",
           "author": null,
           "tag": []
         },
         {
-          "id": "928664d9-4d98-458a-b2f0-88ee79a3fc28",
           "text": "One of Jesus' greatest miracles was having 12 friends by the age of 30.",
           "author": null,
           "tag": []
         },
         {
-          "id": "029524f7-35cd-4e80-98ba-819d5743cd58",
           "text": "Preach the Gospel at all times.  Use words if necessary.",
           "author": null,
           "tag": []
         },
         {
-          "id": "9623aa21-1e53-44f5-9716-b600c462f7f0",
           "text": "Contrast is the mother of clarity.",
           "author": "Oz Guinness",
           "tag": []
         },
         {
-          "id": "b6c01b80-4888-4295-9b14-f46f1d2352fd",
           "text": "The doors of hell are locked on the inside.",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "28cd2980-66e6-4ae8-aec0-48b4521f32e1",
           "text": "The world will never starve for want of wonders; but only for want of wonder.",
           "author": "G.K. Chesterton",
           "tag": []
         },
         {
-          "id": "5c1b3f48-5520-4d8a-9eda-53a7e7f7f15e",
           "text": "A sneer is not an argument.",
           "author": "Jay Wesley Richards",
           "tag": []
         },
         {
-          "id": "2b0a04ba-60d8-4ade-9843-35bba9a8a5cf",
           "text": "You must know your Peter and your Judas;\nPeter has a bad day, Judas had a bad heart;",
           "author": "Judas you release, Peter you restore.",
           "tag": []
         },
         {
-          "id": "96427a77-3374-4922-947b-38b6b3da7b0c",
           "text": "I sat with my anger long enough until she told me her real name was grief.",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "4b17e04d-700b-41ab-9217-9b4980e05e9d",
           "text": "No pain no stimulus, no rest no gain.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "aea5844a-0375-4fa0-81d8-98a175b01dbc",
           "text": "The secret is there is no secret.\nConsistency over intensity;\nProgress over perfection;\nFundamentals over fads.\nOver and over again.",
           "author": null,
           "tag": []
         },
         {
-          "id": "bd0f8659-f102-4bd0-bbeb-80788c90b4ea",
           "text": "Deeds will not be less valiant because they are unpraised.",
           "author": "J.R.R. Tolkien",
           "tag": []
         },
         {
-          "id": "f091140a-5c3f-4a94-bd5d-fff413394ec4",
           "text": "People with siblings have better survival skills because they are experienced in physical combat, psychological warfare, and sensing suspicious activity.",
           "author": null,
           "tag": []
         },
         {
-          "id": "940dd956-b2d9-4e82-98cf-45e21c89a27a",
           "text": "It's not a problem to aim high and miss.\nIt is a problem to aim low and hit.",
           "author": "Michaelangelo",
           "tag": []
         },
         {
-          "id": "dff638c0-4383-4c03-bfb0-962374978432",
           "text": "I've never let schooling get in the way of my education.",
           "author": "Mark Twain",
           "tag": []
         },
         {
-          "id": "d27bfaae-4d95-488e-8cde-396045482dc7",
           "text": "Sin will keep us from the Book;\nOr the Book will keep us from sin.",
           "author": "D.L. Moody",
           "tag": []
         },
         {
-          "id": "c9b3c45f-56a0-4ee8-b5d4-d44320bbb2bd",
           "text": "You're not a citizn of the world trying to get to heaven,\nyou're a citizn of heaven making your way through the world.",
           "author": "Vance Havner",
           "tag": []
         },
         {
-          "id": "3d7110fb-5803-4be3-bd5c-8040a79f92ac",
           "text": "LORD, what we know not, teach us;\nWhat we have not, give us;\nWhat we are not, make us.",
           "author": null,
           "tag": []
         },
         {
-          "id": "d580b8a6-44c9-4958-a33b-14fa80eac498",
           "text": "When a wizard is tired of looking for broken glass in his dinner,\nhe is tired of life.",
           "author": null,
           "tag": []
         },
         {
-          "id": "0fd745e4-63e5-4980-8fde-2af05328d61e",
           "text": "When your outgo exceeds your income your upkeep witll be you downfall.",
           "author": null,
           "tag": []
         },
         {
-          "id": "d2721859-cc2d-4c8f-8c37-505cd1791535",
           "text": "A shroud has no pockets.",
           "author": null,
           "tag": []
         },
         {
-          "id": "c1000e27-20c8-46a2-a480-52175071caca",
           "text": "A man's wife is his faithful looking glass.",
           "author": "General Gordon of Cartoum",
           "tag": []
         },
         {
-          "id": "6dd19aa7-39d1-45ab-addb-0e5728451f6c",
           "text": "We are not saved by fruit, but by faith;\nbut not by fruitless faith.",
           "author": "Tim Keller",
           "tag": []
         },
         {
-          "id": "44820e73-9465-471b-aa5b-0838463434bc",
           "text": "Sow a thought, reap an action;\nSow an action, reap a habit;\nSow a habit, reap a character;\nSow a character, reap a destiny.",
           "author": null,
           "tag": []
         },
         {
-          "id": "3ac3c18c-96b5-4d44-8f8e-8524c4339225",
           "text": "Whenever I'm about to do something I think, \"Would an idiot do that?\" and if they would _I do not do that thing_.",
           "author": "Dwight Schrute",
           "tag": []
         },
         {
-          "id": "eb3872bf-e17f-4c69-89fe-10afc100f3de",
           "text": "Good judgment comes from experience; experience comes from bad judgment.",
           "author": null,
           "tag": []
         },
         {
-          "id": "9bfb43be-6af5-499b-9af2-58ac0cd24a3b",
           "text": "Our own true best selves are always theoretical.",
           "author": null,
           "tag": []
         },
         {
-          "id": "8bcd8099-9456-4228-926a-75a7a96ec62d",
           "text": "Courage is not a virtue,\nbut is the form of a virtue being tested.",
           "author": null,
           "tag": []
         },
         {
-          "id": "fc8f9670-c39c-4239-9241-1bb2833134a8",
           "text": "Before is the soul of lingerie.",
           "author": "Dorothy Parker",
           "tag": []
         },
         {
-          "id": "70f2b59f-f442-49fe-b0c9-b3af3730bb10",
           "text": "Prairie causes you to work not on what you like, but on what you'd like to like.",
           "author": "Paul Graham",
           "tag": []
         },
         {
-          "id": "949e531f-2153-4643-8f22-51f4562190fe",
           "text": "Those are miracles that no merely human brain can work. The artist is merely the sound conduct of a Force that dictates to him what he should do.",
           "author": "Johannes Brahms",
           "tag": [
@@ -552,19 +468,16 @@
           ]
         },
         {
-          "id": "7ec418a3-1bb3-490d-99fc-edce7b788863",
           "text": "He is no fool who gives up what he cannot keep to attain that which he cannot lose.",
           "author": "Jim Elliott",
           "tag": []
         },
         {
-          "id": "667d99a8-4b6c-4c3e-9280-4f5ae56c0766",
           "text": "There is something about humility that appeals to my ego.",
           "author": "Augustine",
           "tag": []
         },
         {
-          "id": "cc90feef-844e-4eec-a48b-cb498766bb02",
           "text": "My things really are written with an appalling lack of practicality!",
           "author": "Johannes Brahms",
           "tag": [
@@ -576,373 +489,311 @@
           ]
         },
         {
-          "id": "93ba7634-62d1-4537-a848-0a94b6de79ab",
           "text": "You can easily judge the character of a man by how he treats those who can do nothing for him.",
           "author": "Johann Wolfgang von Goethe",
           "tag": []
         },
         {
-          "id": "04478cfb-4a2d-4d22-b785-3eaba9a5c853",
           "text": "With the first link, the chain is forged.\nThe first speech censured, the first thought forbidden, the first freedom denied,\nchains us all irrevocably.",
           "author": "Judge Aaron Satie",
           "tag": []
         },
         {
-          "id": "b84bd263-395d-402b-9aee-fb44eea280e4",
           "text": "Christians have nothing to be smug about:\nwe're just one beggar telling another where to find bread.",
           "author": "R.C. Sproul",
           "tag": []
         },
         {
-          "id": "ee35ba32-f22c-4a8e-9c08-e13c00b18a87",
           "text": "Blessed are those who can give without remembering, and take without forgetting.",
           "author": "Elizabeth Asquith Bibesco",
           "tag": []
         },
         {
-          "id": "fe8765b5-c8e8-4d2d-bf9d-e21fd322cd21",
           "text": "The more often he feels without acting, the less he will be able ever to act, and, in the long run, the less he will be able to feel.",
           "author": "Screwtape",
           "tag": []
         },
         {
-          "id": "e221ce6a-4b6d-48f7-84c9-23f4d1416df8",
           "text": "Ruminating on sorrow is bitter work.\nSome things are better to swallow than to chew.",
           "author": "Charles Spurgeon",
           "tag": []
         },
         {
-          "id": "20bb830c-e6f8-4695-aca4-d9913b833c40",
           "text": "I will show you how to do the advanced maneuver but you will only be able to perform it when you can do it faster than you can decide to do it.",
           "author": null,
           "tag": []
         },
         {
-          "id": "af44a4f3-a652-4044-8865-7d46fd0cf09a",
           "text": "The greatest weapon against stress is our ability to choose one thought over another.",
           "author": "William James",
           "tag": []
         },
         {
-          "id": "3ce2f0ca-d392-46f9-9921-27b0e7fa5202",
           "text": "One thing about being on the precipice:\nthe next step is very clear.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "f1f5464e-35bf-4d52-ae41-1351efc7b47e",
           "text": "Everything in moderation including moderation.",
           "author": "Socrates",
           "tag": []
         },
         {
-          "id": "0560be9c-257a-4f6d-8e5e-6b54ea55e512",
           "text": "Don't wait for miracles.\nYour whole life is a miracle.",
           "author": "Albert Einstein",
           "tag": []
         },
         {
-          "id": "9221f90d-1f24-465a-a556-38f5f88f4e4a",
           "text": "Of two evils, choose neither.",
           "author": "Charles Sturgeon",
           "tag": []
         },
         {
-          "id": "9c244fa4-bd84-4158-aaff-3f63f7f38c87",
           "text": "A rut is a grave with the ends kicked out.",
           "author": "Earl Nightingale",
           "tag": []
         },
         {
-          "id": "c64775dc-49c9-44b9-b5ce-0ab61ea16178",
           "text": "I sense a trap.\nNext move?\nSpring the trap.",
           "author": "Obi-Wan Kenobi",
           "tag": []
         },
         {
-          "id": "6a89be52-aee1-44a8-8923-13441f5d33ce",
           "text": "In in response to a book written by 100 critics, \"if I were wrong it would only take one.\"",
           "author": "Albert Einstein",
           "tag": []
         },
         {
-          "id": "21c0716c-1807-44e6-a858-0df564a03b59",
           "text": "When you go into the end zone,\nact like you've been there before.",
           "author": "Vince Lombardi",
           "tag": []
         },
         {
-          "id": "49833350-0801-417e-a896-7dbf7750ab76",
           "text": "Talent hits a target no one else can hit.\nGenius hits a target no one else can see.",
           "author": "Arthur Schopenhauer",
           "tag": []
         },
         {
-          "id": "6749da54-6a1d-4264-8181-5bb9996d33e8",
           "text": "I believe in Christianity as I believe the sun has risen;\nnot only because I see it,\nbut because by it I see everything else.",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "fe344713-d4eb-4797-9a6e-faa790b76508",
           "text": "You have been chosen, and you must therefore use such strength and heart and wits as you have.",
           "author": "J.R.R. Tolkien",
           "tag": []
         },
         {
-          "id": "74f8505d-f70f-4dbc-81a3-431d81648e25",
           "text": "I'm all about loyalty- in fact, part of what I'm being paid for is my loyalty.\nBut if there were somewhere else that values loyalty more highly, I'm going wherever they value loyalty the most.",
           "author": "Dwight Schrute",
           "tag": []
         },
         {
-          "id": "835ef2f0-03a7-4c8b-a254-d89f7fb40191",
           "text": "Don't interrupt your enemy while they are making mistakes.",
           "author": "Napoleon Bonaparte",
           "tag": []
         },
         {
-          "id": "d40d4c2f-fb24-489b-aa97-a38876eb07b5",
           "text": "In academia no one cares what you've done, they only care what you've read.\nIn industry no one cares what you've read, they only care what you've done.",
           "author": "J. Youngblood",
           "tag": []
         },
         {
-          "id": "3b1ed729-9f59-4ffc-bc3c-ce6f0b17b840",
           "text": "Passion is the genesis of genius.",
           "author": "GALILEO GALILEI",
           "tag": []
         },
         {
-          "id": "f49a9b63-fc3d-4c59-9739-eea206e87fda",
           "text": "Only a fool learns from his own mistakes.\nThe wise man learns from the mistakes of others.",
           "author": "Otto von Bismarck",
           "tag": []
         },
         {
-          "id": "5acfa584-26e4-4949-a92c-e642748644f8",
           "text": "Give before it hurts.",
           "author": "Calvin",
           "tag": []
         },
         {
-          "id": "ea6791f6-622e-42fd-ab60-dabdf1e342c0",
           "text": "Some people are so poor all they have is money.",
           "author": "Bob Marley",
           "tag": []
         },
         {
-          "id": "db7fcc17-7e19-45f4-873d-31754e9c84ae",
           "text": "The rule of heaven: thy will be done.\nThe rule of hell: my will be done.",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "ecc1acd3-ee16-441e-836d-80019e0b2f74",
           "text": "The Scriptures are shallow enough for a babe to come and drink without fear of drowning\nand deep enough for theologians to swim in without ever touching the bottom.",
           "author": "St. Jerome",
           "tag": []
         },
         {
-          "id": "a9b96f95-6e32-48dc-84a0-270342d314f3",
           "text": "Eve is oft maligned alone for giving Adam the apple,\nbut really is was a bad pear.",
           "author": null,
           "tag": []
         },
         {
-          "id": "d516f18c-e44a-4de0-a796-24cfd90ed13e",
           "text": "Hypocrites do the devil's drudgery in Christ's livery.",
           "author": "Matthew Henry",
           "tag": []
         },
         {
-          "id": "0a35b226-28a6-49cb-ac49-6a7ac9db40ac",
           "text": "I heard God's call and I'm pretty sure he was talking to the guy behind me;\nbut I'm going to go ahead and do what He said just in case.",
           "author": null,
           "tag": []
         },
         {
-          "id": "f94df8f6-756d-4024-83e3-882dcb324b5a",
           "text": "Hell: the greatest monument to human freedom.",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "795809f1-315b-4ca6-8e81-cc6fb2c87803",
           "text": "Jonah sat and waited for God to come around to his way of thinking.\nAll the while God waits for we Jonah's to come around to his way of loving.",
           "author": "Thomas John Carlisle",
           "tag": []
         },
         {
-          "id": "19072a82-3134-49fe-906b-285155cf9491",
           "text": "First they came for the socialists, and I did not speak out— because I was not a socialist.\nThen they came for the trade unionists, and I did not speak out— because I was not a trade unionist.\nThen they came for the Jews, and I did not speak out—because I was not a Jew.\nThen they came for me—and there was no one left to speak for me.",
           "author": "Martin Niemöller",
           "tag": []
         },
         {
-          "id": "d1080fc4-ceab-4e04-9a6e-13523206be28",
           "text": "As a nation of free men we will live forever or die by suicide.",
           "author": "Abraham Lincoln",
           "tag": []
         },
         {
-          "id": "b08f7d1b-1932-41ec-a7c0-634928fda2d9",
           "text": "A metaphor always stands for something real.",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "ed162e76-5e16-464e-8d97-1c51248e02bc",
           "text": "I was saved; I am saved; I am being saved.",
           "author": "Earl Rademacher",
           "tag": []
         },
         {
-          "id": "6ccf1ed2-7c16-489b-a19d-234d34a49a7e",
           "text": "All people, regardless of worldview, are made in the image of God and I intend to treat them that way.",
           "author": "Lewis Lennox",
           "tag": []
         },
         {
-          "id": "3cf8b3fa-8331-4b1f-b320-8d8d0d42f967",
           "text": "The real conspiracy theorists are the ones who believe the government cares for them, the media would never lie to them, and pharmaceutical companies making billions of dollars selling them drugs want to cure them.",
           "author": null,
           "tag": []
         },
         {
-          "id": "2fb8e101-2264-4b35-b777-7ad1581e796c",
           "text": "Politics: the art of convincing decent people to forget that the lesser of two evils is still evil.",
           "author": "Edward Snowden",
           "tag": []
         },
         {
-          "id": "7ac7c0b2-2ad4-4c49-8560-1c1824411c85",
           "text": "Science takes things apart to see how they work.\nReligion puts things together to see what they mean.\nThey speak different languages and use different powers of the brain.",
           "author": "Lord Jonathan Sacks",
           "tag": []
         },
         {
-          "id": "eec73c23-5b13-4be4-aa07-e400e0ede314",
           "text": "Our scars show that we have suffered...and healed.",
           "author": null,
           "tag": []
         },
         {
-          "id": "6ef2c1ef-e6e9-4643-a214-4792f72555ed",
           "text": "A writer needs three things, experience, observation, and imagination,\nany two of which, at times any one of which, can supply the lack of the other.",
           "author": "William Faulkner",
           "tag": []
         },
         {
-          "id": "db12c0a5-0bc9-4fd0-94d4-9759379589b4",
           "text": "It does not do to leave a live dragon out of your calculations, if you live near him.",
           "author": "J.R.R. Tolkien",
           "tag": []
         },
         {
-          "id": "0460ac50-a592-4ebd-9abe-3a5cae318d96",
           "text": "Easy reading is damned hard writing.",
           "author": "Nathaniel Hawthorne",
           "tag": []
         },
         {
-          "id": "a6d0390f-0f44-4aba-b179-8a84539cf416",
           "text": "Either write something worth reading or do something worth writing.",
           "author": "Benjamin Franklin",
           "tag": []
         },
         {
-          "id": "f8f80837-2b37-44b5-b8bd-9e5e443806d0",
           "text": "Sometimes ideas just come to me.\nOther times I have to sweat and almost bleed to make ideas come.\nIt’s a mysterious process, but I hope I never find out exactly how it works.",
           "author": "J.K. Rowling",
           "tag": []
         },
         {
-          "id": "39eba182-f3da-4d24-9f64-b357943416f6",
           "text": "Life is like a helicopter\nI don't know how to operate a helicopter.",
           "author": null,
           "tag": []
         },
         {
-          "id": "de34c896-f9cc-48d0-9e2f-45f2b358c66e",
           "text": "Know how to solve every problem that has been solved.",
           "author": "Richard P. Feynman",
           "tag": []
         },
         {
-          "id": "a5c86e85-455b-4412-8ab1-8a783a1c3e9c",
           "text": "It would seem our Lord finds our desires not too strong, but too weak.",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "48326ab2-e6a6-4ae5-bfb8-0ef408c29412",
           "text": "If you want a happy ending, that depends, of course, on where you stop your story.",
           "author": "Orson Welles",
           "tag": []
         },
         {
-          "id": "4ea65d4c-1f26-4bc4-81a6-3ab23e8f2c61",
           "text": "When the student is ready the teacher will appear.\nWhen the student is truly ready the teacher will disappear.",
           "author": "Tao Te Ching",
           "tag": []
         },
         {
-          "id": "23d46450-33f9-49d0-a8a2-a86373787207",
           "text": "A smart person expresses less than 10% of what they think.\nA stupid person thinks about less than 10% of what they express.",
           "author": null,
           "tag": []
         },
         {
-          "id": "c0abf374-a58d-4988-9945-6804ecc5429b",
           "text": "If you don't have time to do it right, when will you have time to do it over?",
           "author": "John Wooden",
           "tag": []
         },
         {
-          "id": "567fdcfc-423a-4244-ab64-769110cf6ed5",
           "text": "The greater danger for most of us lies not in setting our aim too high and falling short;\nbut in setting our aim too low, and achieving our mark.",
           "author": "Michaelangelo",
           "tag": []
         },
         {
-          "id": "82f81189-a7e5-4e1d-8b73-fe052e5208c5",
           "text": "War is a place where\nyoung people who don't know each other and don't hate each other\nkill each other\nbased on decisions made by old people who know each other and hate each other\nbut don't kill each other.",
           "author": "Paul Valéry",
           "tag": []
         },
         {
-          "id": "a5ddc6ed-b559-473e-890e-949e484b9617",
           "text": "Remember, if you have a problem with your parachute: you have the rest of your life to figure it out.",
           "author": null,
           "tag": []
         },
         {
-          "id": "0f0f48c8-9de9-4913-a4a3-150df383662f",
           "text": "When you get what you want that is God's direction.\nWhen you don't get what you want that is God's protection.",
           "author": "Shannon L. Adler",
           "tag": []
         },
         {
-          "id": "33fd7292-382e-483b-837c-c0dc4d8a80de",
           "text": "The skill of writing is to create a context in which other people can think.",
           "author": "Edwin Schlossberg",
           "tag": []
         },
         {
-          "id": "d736d5a2-3d31-4a40-b42d-c77adeae0ca6",
           "text": "Three contractors are bidding to fix a broken fence at the White House.\nThe Minnesota contractor says, \"I figure the job will run about $900.  $400 for materials, $400 for my crew, and $100 profit.\"\nThe Tennessee contractor says, \"I can do this job for $700. $300 for materials, $300 for my crew, and $100 profit.\"\nThe Chicago contractor leans over to the White House official and whispers, \"$2,700.\"\nThe official, incredulous, says, \"You didn't even measure like the other guys!  How did you come up with such a high figure?\"\nThe Chicago contractor whispers back, \"$1000 for me, $1000 for you, and we hire the guy from Tennessee to fix the fence.\"",
           "author": "\"Done!\" replies the government official. And that, my friends, is how our government works.",
           "tag": []
         },
         {
-          "id": "717348aa-e086-48cb-b674-da7273d5f49c",
           "text": "The United States had become a place where entertainers and professional athletes were mistaken for people of importance.\nThey were idolized and treated as leaders; their opinions were sought on everything and they took themselves just as seriously—\nafter all, if an athlete is paid a million or more a year, he knows he is important…\nso his opinions of foreign affairs and domestic policies must be important, too, even though he proves himself to be both ignorant and subliterate every time he opens his mouth.\n(Most of his fans were just as ignorant and unlettered; the disease was spreading.)",
           "author": "Robert A. Heinlein - To Sail Beyond the Sunset 1987",
           "tag": []
         },
         {
-          "id": "0f6bce60-7104-4698-809e-4aea87548c21",
           "text": "The only true immortality lies in one's children.",
           "author": "Johannes Brahms",
           "tag": [
@@ -950,385 +801,321 @@
           ]
         },
         {
-          "id": "a639683b-5c95-4044-a407-f31c112fa96d",
           "text": "If you want to know who controls you, look at who you are not allowed to criticize.",
           "author": null,
           "tag": []
         },
         {
-          "id": "f56d90a2-2341-4a95-899b-001cfb83d72a",
           "text": "Never appeal to a man's better nature, he may not have one.",
           "author": null,
           "tag": []
         },
         {
-          "id": "93961bf5-b3b8-41f0-9394-f95c26fd1ef4",
           "text": "A civilization which leaves so large a number of its participants unsatisfied and drives them into revolt neither has nor deserves the prospect of a lasting existence.",
           "author": "Sigmund Freud",
           "tag": []
         },
         {
-          "id": "29eb4936-5a4a-4a94-a533-0854572fc2b9",
           "text": "Don't mistake my generosity for generosity.",
           "author": "whiterose",
           "tag": []
         },
         {
-          "id": "1228d869-6de4-44b4-bc8f-294095eb14f0",
           "text": "If someone shows you who they really are...\nbelieve them.\nMr. Eisenhut",
           "author": null,
           "tag": []
         },
         {
-          "id": "545d106a-14f7-4e67-a87e-7794bc399601",
           "text": "The true character of a man is decided in the battle between him and his fallen nature;\nThe only real victory is to deny it battle.",
           "author": null,
           "tag": []
         },
         {
-          "id": "11c247dd-1e5a-4831-a7e9-97865a2cb544",
           "text": "Perhaps I am a providential shipwreck.",
           "author": null,
           "tag": []
         },
         {
-          "id": "051b2389-245b-4660-a5e0-3e6d0fd209f6",
           "text": "In Sterquiliniis Invenitur\n__In filth it will be found__",
           "author": "Carl Jung",
           "tag": []
         },
         {
-          "id": "7523fda2-22a5-40af-a394-29c4bf9c6855",
           "text": "With powerlessness comes agression.",
           "author": "Andrew Huberman",
           "tag": []
         },
         {
-          "id": "1329e4f7-d517-4648-8998-a634375d3e69",
           "text": "Cowards and champions have the same fears.",
           "author": null,
           "tag": []
         },
         {
-          "id": "ccd3a98b-4596-4cc4-94ab-92ab717dede3",
           "text": "Be willing to do today was others aren't,\nSo that you're able to do tomorrow what others can't.",
           "author": "Matt Fraser",
           "tag": []
         },
         {
-          "id": "18ca5b8b-4a23-4df7-b63a-95b2ef69da1f",
           "text": "Never use too many over-the-top, superfluous, excessively narrow, hypersyllabic adjectives.",
           "author": null,
           "tag": []
         },
         {
-          "id": "b3deee89-1273-444b-889a-db9fca2fee94",
           "text": "One of the main functions of organized religion is to protect people against a direct experience of God.",
           "author": "Carl Jung",
           "tag": []
         },
         {
-          "id": "2f396c66-5a50-4c9e-8558-7595e46591e0",
           "text": "If it's not counted then it doesn't count.",
           "author": null,
           "tag": []
         },
         {
-          "id": "32e3e341-c411-43ac-841b-8879f50809ad",
           "text": "Look to the horizon but watch your step.",
           "author": null,
           "tag": []
         },
         {
-          "id": "8314d263-b7b1-4509-aacf-0a1bdf98ceba",
           "text": "One out of one of us will die; and one of us will be the next one.",
           "author": "Sam Cherian",
           "tag": []
         },
         {
-          "id": "fa00ccb3-4cac-4ba7-96d5-ff285a40875b",
           "text": "Of every hundred men in war:\nten shouldn't be there,\neighty are nothing but targets,\nnine are real fighters, and we are lucky to have them, for they make the battle.\nAh, but the one, one is a warrior, and he will bring the others back.",
           "author": "Herman Melville",
           "tag": []
         },
         {
-          "id": "b179f981-a989-484b-a9a6-8432c3798b39",
           "text": "Nature is a book written in “the language of mathematics”.\nIf we cannot understand that language, we will be doomed to wander about as if in a dark labyrinth.",
           "author": "Galileo Galilei",
           "tag": []
         },
         {
-          "id": "749bfc23-8a32-400c-b372-86220d80b868",
           "text": "Providence is the belief that all of history has been orchestrated to bring you into the presence of God at this very moment- and that every human can claim this.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "e6ac5d0c-f633-472d-b6f8-6b05dd2e00a9",
           "text": "Give us one free miracle and we'll explain the rest.",
           "author": "Terrance McKenna",
           "tag": []
         },
         {
-          "id": "047b3127-790e-4069-a07a-b2333cea0a49",
           "text": "If an apple falls from a tree because of a law of nature,\nThen is it not a person and, further, a citizen.",
           "author": "C.S. Lewis.",
           "tag": []
         },
         {
-          "id": "f57e3c07-cb95-4fad-a05d-e52f02367efd",
           "text": "As soon as you say never here come the kids nevering like they never nevered before.",
           "author": "Erma Bombeck",
           "tag": []
         },
         {
-          "id": "35e23ae3-94f7-486a-a9d9-f027ffbcbace",
           "text": "If men define situations as real,\nthey are real in their consequences.",
           "author": "The Thomas Theorem",
           "tag": []
         },
         {
-          "id": "0ea40019-ad95-42a3-a7b1-b14f2150d5da",
           "text": "The only person who never makes a mistake is the person who does nothing.",
           "author": "Albert Einstein",
           "tag": []
         },
         {
-          "id": "4372f884-245a-4d87-8fde-143033d05a08",
           "text": "A correct decision is wrong when it's made too late.",
           "author": "Lee Iococa",
           "tag": []
         },
         {
-          "id": "1be6155d-8adc-4501-83ac-635163ccb9f0",
           "text": "Everybody counts or nobody counts.",
           "author": "Heironymous Bosch",
           "tag": []
         },
         {
-          "id": "4df8b1ad-4841-481f-beb9-0b770d7e8eb7",
           "text": "At the end of the day a man is no better than the pain he has caused the one's he loves;\nAnd what he has done to make it better.",
           "author": "Rycroft Philostrate",
           "tag": []
         },
         {
-          "id": "cd6c626d-cc43-4af6-b32e-48bfaf2995dc",
           "text": "If I have seen further it is by standing on the shoulders of giants.",
           "author": "Isaac Newton",
           "tag": []
         },
         {
-          "id": "9462fe5f-87eb-4ee9-a0db-6879a490a109",
           "text": "Nothing is more certain than death,\nAnd nothing more uncertain than the time of death.",
           "author": "Thomas Paine",
           "tag": []
         },
         {
-          "id": "c4b5d9e2-85a7-4db1-ae14-7d90087ac24e",
           "text": "It is amazing how complete is the delusion that beauty is goodness.",
           "author": "Leo Tolstoy",
           "tag": []
         },
         {
-          "id": "d36b12b6-519c-4693-9bbb-3c5eeba51bf7",
           "text": "Everyone has the right to be stupid,\nSome people abuse the privilege.",
           "author": "Joseph Stalin",
           "tag": []
         },
         {
-          "id": "857188a6-e614-48fe-a2d9-5dc1ba309e30",
           "text": "Capitalism is people exploiting people,\nUnder communism it's exactly the opposite.",
           "author": "...",
           "tag": []
         },
         {
-          "id": "e5adf008-8755-4524-b83d-0f86a10ecc9b",
           "text": "The Bible is the greatest of all books; to study it is the noblest of all pursuits; to understand it, the highest of all goals.",
           "author": "Charlie Ryrie.",
           "tag": []
         },
         {
-          "id": "6f21fcde-d38c-42bf-9abe-b5fa6b5f9ff6",
           "text": "It does not do to dwell on dreams and forget to live.",
           "author": "Albus Dumbledore",
           "tag": []
         },
         {
-          "id": "7ee7a2b4-0cbc-4d05-be3b-af9cae95f223",
           "text": "You're unique, just like everyone else.",
           "author": "Margaret Mead",
           "tag": []
         },
         {
-          "id": "0abc99b4-caaf-46e9-bbf0-24f6512ba499",
           "text": "How you get there's the worthier part.",
           "author": "Shepherd Book",
           "tag": []
         },
         {
-          "id": "57951647-808e-43e5-b389-3d9579d4b048",
           "text": "Never doubt that a small group of thoughtful, committed citizens can change the world;\nindeed, it's the only thing that ever has.",
           "author": "Margaret Mead",
           "tag": []
         },
         {
-          "id": "12914481-8e8e-4ada-988d-72afe84a112b",
           "text": "The world will accept the judgment you place upon yourself.",
           "author": null,
           "tag": []
         },
         {
-          "id": "cf1a7e1a-9713-48a9-b6c8-ae395a8392ce",
           "text": "An outsider is a catalyst:\nEssential and often burned up in process.",
           "author": null,
           "tag": []
         },
         {
-          "id": "e4a9b84e-3927-4db4-9f5f-41de049a6da1",
           "text": "Have strong opinions, loosely held,\nIf you want to influence your neighbor.",
           "author": null,
           "tag": []
         },
         {
-          "id": "65d6ebca-9c31-46b7-b3e1-ccdfdb278356",
           "text": "More important thean learning the truth,\nIs to unlearn what is untrue.",
           "author": "Antisthenes",
           "tag": []
         },
         {
-          "id": "43b46b45-d309-4da5-83bb-415deab372c4",
           "text": "Before you say something negative about someone else\nSay something negative about yourself.",
           "author": null,
           "tag": []
         },
         {
-          "id": "bf9e5df5-876d-4d55-b4a9-9d02ab2f2062",
           "text": "What gets us in trouble is not what we know-\nIt's what we know for sure that just ain't so.",
           "author": "Mark Twain",
           "tag": []
         },
         {
-          "id": "d298dfdb-e03a-42d9-a41a-67ad301a6773",
           "text": "Democracy is the distribution of power.\nTyranny is the concentration of power.",
           "author": null,
           "tag": []
         },
         {
-          "id": "edc8029e-c1d5-41d9-b059-03b7416487e0",
           "text": "English is what happens when Vikings learn Latin and use it to shout at Germans.",
           "author": "Kevin McLeod",
           "tag": []
         },
         {
-          "id": "1c050fa9-d51e-4c57-8846-f4a8c4534583",
           "text": "There are 2 kinds of people on this world:\nThose who can extrapolate from limited data,",
           "author": null,
           "tag": []
         },
         {
-          "id": "a28ce9b2-2f5a-46a9-b7af-39c49bb94303",
           "text": "If there's one thing I learned in the army:\nIt's to be positive,\nespecially when you don't know what you're talking about.",
           "author": "Major General Waverly",
           "tag": []
         },
         {
-          "id": "03043230-bdc2-46cd-9754-e93fc86b7456",
           "text": "The mystery is not that God hated Esau;\nBut that God loved Jacob.",
           "author": null,
           "tag": []
         },
         {
-          "id": "1551edce-62d6-4cd3-be60-0a42ed8e4582",
           "text": "Nobody owns life but anyone who holds a frying pan holds death.",
           "author": null,
           "tag": []
         },
         {
-          "id": "ce551c81-89f2-4a69-861b-c745de2e33c3",
           "text": "You can't pickpocket a naked man.",
           "author": null,
           "tag": []
         },
         {
-          "id": "a8d73479-448b-46b6-b933-2c09c2e2cd3e",
           "text": "No one is against you,\nthey are for themselves.",
           "author": "M. Calderon",
           "tag": []
         },
         {
-          "id": "586ca968-6004-47ae-8216-6f4999e3c83c",
           "text": "Dictionary, n. A malevolent literary device for cramping the growth of a language and making it hard and inelastic.",
           "author": "Ambrose Bierce",
           "tag": []
         },
         {
-          "id": "17a770f2-1fa0-45b6-925f-e02c4d8b78bc",
           "text": "Fear has two meanings:\nForget Everything And Run\nor",
           "author": "Face Everything And Rise",
           "tag": []
         },
         {
-          "id": "8d1356fb-b878-4b90-826d-2286fe3078b1",
           "text": "A man's reach should exceed his grasp, or what's a heaven for?",
           "author": "Robert Browning",
           "tag": []
         },
         {
-          "id": "45198e8b-2d5c-4e08-8c61-cf21606bae16",
           "text": "At the end of the day you have to make a choice:\nWhether to live with yourself or be happy.",
           "author": "Michael Scott",
           "tag": []
         },
         {
-          "id": "77279508-6409-4e38-9ccf-bcc6352c98a8",
           "text": "If _onlys_ and _justs_ were candies and nuts then everyday would be Erntedankfest.",
           "author": "Dwight Schrute",
           "tag": []
         },
         {
-          "id": "f703c817-f785-4a52-b23f-264ed4140c02",
           "text": "We need to stop just pulling people out of the river,\nWe need to go upstream and find out why they're falling in.",
           "author": "Desmond Tutu",
           "tag": []
         },
         {
-          "id": "559d2f00-832d-403a-a784-4a2891c650f3",
           "text": "When you're successful you have everything you need,\nWhen you're fulfilled your give everything you've got.",
           "author": "Keith Cunningham",
           "tag": []
         },
         {
-          "id": "72d4321f-bf06-4b1f-978d-1b9c6efe5e80",
           "text": "To suffer terribly and know yourself as the cause, that is hell.",
           "author": "Jordan Peterson",
           "tag": []
         },
         {
-          "id": "a1d4c2b9-7090-4fac-afaa-76c64d98eb1c",
           "text": "Intuition is a powerful tonic.",
           "author": null,
           "tag": []
         },
         {
-          "id": "f6ea004c-a22e-4da4-8e8c-966868c9cedd",
           "text": "I don't trust someone who is nice to me but rude to the waiter;\nBecause they would treat me the same way if I was in that position.",
           "author": "Muhammad Ali",
           "tag": []
         },
         {
-          "id": "169dd35c-ca94-40af-9017-708ad83f3da3",
           "text": "Trust those who seek the truth,\nDoubt those who claim they have found it.",
           "author": null,
           "tag": []
         },
         {
-          "id": "a521afe6-debc-49ea-8df1-7fcb9ff79be0",
           "text": "How to politely tell someone they're stupid:\n__Wisdom has always been chasing you, but you've always been faster__",
           "author": null,
           "tag": []
         },
         {
-          "id": "68d95eb9-f920-4ccc-91f6-95dc19ed0d36",
           "text": "Those who enjoy their own emotionally bad health and who habitually fill their own minds with the rank poisons of suspicion, jealousy and hatred, as a rule take umbrage at those who refuse to do likewise, and they find a perverted relief in trying to denigrate them.",
           "author": "Johannes Brahms",
           "tag": [
@@ -1338,751 +1125,626 @@
           ]
         },
         {
-          "id": "9229d3d2-0270-4d5a-8902-baed6d5ddb20",
           "text": "Wine tastes sweetest to those in whose trials it was fermented.",
           "author": null,
           "tag": []
         },
         {
-          "id": "cb010772-5ed6-45ee-aa63-18789dd2eb0c",
           "text": "If, for some reason your life functions ceased, my most precious one,\nI would collapse, I would draw the shades and I would live in the dark.\nI would never get out of my slar pad or clean myself.\nMy fluids would coagulate, my cone would shrivel,\nand I would die, miserable and lonely.\nThe stench would be great.",
           "author": "Baldar Conehead",
           "tag": []
         },
         {
-          "id": "9ecf5d45-882e-486f-8b7c-2d2ed5efa2a7",
           "text": "People change when\nthey hurt enough they have to,\nthey see enough they're inspired to,\nthey learn enough they want to,\nthey recieve enough they're able to.",
           "author": "John C. Maxwell",
           "tag": []
         },
         {
-          "id": "66e67373-e1c7-4a81-9034-91d88cbb2749",
           "text": "If you love a flower, don't pick it up.\nBecause if you pick it up it dies and it ceases to be what you love.\nSo if you love a flower, let it be.",
           "author": "Osho",
           "tag": []
         },
         {
-          "id": "702e8721-2e20-4053-a37a-0bffe3eb69b2",
           "text": "Mathematics is the science of analogy.",
           "author": "Atiyah",
           "tag": []
         },
         {
-          "id": "a9655485-846f-44b9-8aca-3a89fa0dd2be",
           "text": "You cannot change your mind with your mind.\nYou can only change your mind with your body.",
           "author": "Alan Huberman",
           "tag": []
         },
         {
-          "id": "5be3663b-5f14-4d19-a89c-7fae8f322bc2",
           "text": "our preferences do not determine what's true.",
           "author": "Carl Sagan",
           "tag": []
         },
         {
-          "id": "5f39cc60-59b6-452f-888a-3a595d039d9f",
           "text": "Don't pretend to be what you're not, instead, pretend to what you want to be, it is not pretence, it is a journey to self realization.",
           "author": "Michael Bassey Johnson",
           "tag": []
         },
         {
-          "id": "0a2e09cf-4d18-4f45-b29c-1e6c2ec8f414",
           "text": "You can tell all you need to know about a man's character by how he speaks to his children and how his wife speaks to him.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "91079df2-85cf-4d91-81db-f0c2e2935c08",
           "text": "The goal of a narcissist is to attain moral virtue without undergoing any of the suffering necessary to attain it.",
           "author": "Jordan Peterson",
           "tag": []
         },
         {
-          "id": "f6242c9a-dd2c-488b-bc9f-faf135a44adb",
           "text": "A candle doesn't lose any flame by lighting another candle.",
           "author": null,
           "tag": []
         },
         {
-          "id": "df7e47bd-8cf3-4ceb-9ee9-639c06401cca",
           "text": "I can't believe what you say\nbecause I see what you do.",
           "author": "James Baldwin",
           "tag": []
         },
         {
-          "id": "941c33ca-f7ff-41f5-b02f-ed08d991aa23",
           "text": "Those who can make you believe absurdities\ncan make your commit atrocities.",
           "author": "Voltaire",
           "tag": []
         },
         {
-          "id": "0d436203-85a2-4da3-b734-e3d62e725829",
           "text": "A lie doesn’t become truth,\nwrong doesn’t become right\nand evil doesn’t become good\njust because it’s accepted by a majority.",
           "author": "Booker T. Washington.",
           "tag": []
         },
         {
-          "id": "baee76b6-d786-49e0-a6ee-660ea9a15dfc",
           "text": "Challenge fear;\nOvercome it;\nBut deny it at your peril.",
           "author": null,
           "tag": []
         },
         {
-          "id": "da409069-4ad3-4dc2-9490-88a4e43e71e2",
           "text": "Smooth seas do not make skilled sailors.",
           "author": null,
           "tag": []
         },
         {
-          "id": "80c7e3e1-a725-45b4-b339-c026967d6f34",
           "text": "English is hopelessly complicated, extra letters and redundant vowels, like 'gh' and 'ou', abond.\nAs wel, certin leters, like 'c' and 'y', have multyple fonymz wich mace them unycycary.\nAlso, cyrtn condz, like 'th' and 'sh', can be ynferd witot te xtra lytr.\nI kanot fathym a mor frynytic kakofony of grafymc tan tyz,\nTo a cyrtin potry yxysts yn yts complyxty- arysng and rysydyng yn ty mynd of bot atr an redr.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "31cd2a34-ecd5-427d-b2c5-ae28ee04244a",
           "text": "One shan't rely on the written word alone:\nIf you read read as read instead of read your to-do becomes done without doing.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "ba571581-7680-4845-af1d-726cd5f993de",
           "text": "The problem with quotes found on the Internet\nis that they are often not true.",
           "author": "Abraham Lincoln",
           "tag": []
         },
         {
-          "id": "4a32b8d7-b1ae-42ae-a3e8-4fd11c20a8dc",
           "text": "Tolerance will reach such a level\nthat intelligent people will be banned from thinking\nso as not to offend the imbecile.",
           "author": "Dostoievski.",
           "tag": []
         },
         {
-          "id": "95f5bc28-55de-4f08-9365-702ecf5c51d7",
           "text": "It is only when a mosquito lands on your testicles that you realize\nthere is always a way to solve problems without violence.",
           "author": null,
           "tag": []
         },
         {
-          "id": "f01375f4-1043-4e58-90b6-08350b1cc337",
           "text": "Money attracts the woman you want,\nstruggle attracts the woman you need.",
           "author": null,
           "tag": []
         },
         {
-          "id": "693808a9-1c12-4b0c-9218-62f775971984",
           "text": "First do it, then do it right, then do it better.",
           "author": "Addy Osmani",
           "tag": []
         },
         {
-          "id": "a988eacb-e1c2-4f5f-b427-efeb3b6abeff",
           "text": "Morality is doing what's right in spite of what you're told.\nObedience is doing what you're told in spite of what's right.",
           "author": null,
           "tag": []
         },
         {
-          "id": "250ba745-9c43-4de4-a051-286d224b73ce",
           "text": "You are better off hurt than hardened.",
           "author": null,
           "tag": []
         },
         {
-          "id": "707a0298-9223-4b35-872a-b865f61591c5",
           "text": "Plans are worthless, but planning is essential.",
           "author": "Dwight Eisenhower",
           "tag": []
         },
         {
-          "id": "c282ff0e-4859-41f3-9db6-f2e2aeb22470",
           "text": "No one is going to give you the education you need to overthrow them.\nNobody is going to teach you your true history,\nteach you your true heroes,\nif they know that that knowledge will help set you free.",
           "author": "Assata Shakur",
           "tag": []
         },
         {
-          "id": "41d8ef8e-3ea9-4770-a177-0c5bda4885a6",
           "text": "When the devil ignores you,\nyou know you're doing something wrong.",
           "author": null,
           "tag": []
         },
         {
-          "id": "3d979b64-2259-4c2e-9c41-361975e753b4",
           "text": "Compliance is doing what another wants,\nSubmission is making their wants your own.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "e865f238-3d29-4b92-b039-396a70e2d14c",
           "text": "Bad leadership is unbiblical.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "3264e374-b0f9-43dc-abaf-c56aae8cf82f",
           "text": "Don't fight unless you have to.\nBut if you have to then fight like you're the third monkey on the ramp to Noah's ark and, brother, it's starting to rain...",
           "author": null,
           "tag": []
         },
         {
-          "id": "135b1f1e-06c0-4a9c-a5e9-1ff0cb8ca03d",
           "text": "Don’t wear yourself out wrestling with a pig.\nYou just get muddy and the pig likes it.",
           "author": null,
           "tag": []
         },
         {
-          "id": "e0ad8a7b-9878-4988-baf6-d97fafacce85",
           "text": "All science is either physics or stamp collecting.",
           "author": "Ernest Rutherford",
           "tag": []
         },
         {
-          "id": "a1ff71fa-b5c1-4520-9cb6-a5638f5c9561",
           "text": "We simply cannot maintain wholeness\nif we talk and walk differently\nthan we see.",
           "author": "Stephen Covey",
           "tag": []
         },
         {
-          "id": "d97bc430-58e5-4714-9af5-777bedf15596",
           "text": "What you are shouts so loudly in my ears\nI cannot hear what you say.",
           "author": "Emerson",
           "tag": []
         },
         {
-          "id": "1738f4b7-8bbe-49e2-b285-ad3c5717df4d",
           "text": "If God wants to teach you peace,\nhe’ll put you in chaos.\nIf God wants you to learn love,\nhe’ll put you around an unlovely person.",
           "author": "Rick Warren",
           "tag": []
         },
         {
-          "id": "3ce8c93c-abe7-4183-ba01-bfddf45e9901",
           "text": "When you feel...\n...angry, go exercise\n...envy, meditate\n...anxiety, give thanks\n...irritation, ruminate\n...tired, go-to bed\n...uninspired, take a shower\n...doubtful, write",
           "author": null,
           "tag": []
         },
         {
-          "id": "801c39cf-be4c-4adb-b52d-29c7e1d4c127",
           "text": "A leader is one of whom it will be said, he was one of them but demonstrably in charge.",
           "author": "Stanley McCrystal.",
           "tag": []
         },
         {
-          "id": "665a36e1-fa00-4fac-b018-c733320e1c34",
           "text": "I can afford nouns, but adjectives are expensive.",
           "author": "Jimmy Youngblood",
           "tag": []
         },
         {
-          "id": "67d743f9-ff6b-4200-a87a-7b8e4fef6cd2",
           "text": "Being powerful is like being a lady.\nIf you have to tell people you are, you aren't.",
           "author": "Margaret Thatcher",
           "tag": []
         },
         {
-          "id": "51135501-0671-41b4-8601-ed0451c84049",
           "text": "Our talents are living things.\nWe give birth to them, nourish them,\ntill they grow and become immortal.",
           "author": "Michael Bassey Johnson",
           "tag": []
         },
         {
-          "id": "9408d602-8a49-499d-b507-1e099cd1fd8e",
           "text": "Never underestimate the man who overestimates himself.",
           "author": null,
           "tag": []
         },
         {
-          "id": "6022ef84-a262-4ee3-aa43-fe689f5c62b5",
           "text": "It is easier to find men who will volunteer to die,\nthan to find those who are willing to endure pain with patience.",
           "author": "Caesar Augustus",
           "tag": []
         },
         {
-          "id": "d10c0ad6-e58b-4a94-9eae-edf4d28eb32e",
           "text": "Libertarians fight for freedom,\nLiberals fight for the helpless,\nConservatives fight for civilization;\nAll three are entirely necessary.",
           "author": "Michael Shellenberger",
           "tag": []
         },
         {
-          "id": "d8b5135e-fad1-408b-bda3-30264ae3fc81",
           "text": "If you don't have friends who are not like you then you're in trouble.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "fc28e613-3658-4508-8ea2-922788e35d73",
           "text": "To know that we know what we know, and that we do not know what we do not know, that is true knowledge.",
           "author": "Confuscius",
           "tag": []
         },
         {
-          "id": "01bab237-414e-450f-93a0-56a5e1633351",
           "text": "We have no more right to consume happiness without producing it than to consume wealth without producing it.",
           "author": "George Bernard Shaw",
           "tag": []
         },
         {
-          "id": "27c5dc1b-856a-401c-bbe5-d0a3ed806425",
           "text": "Life contains but two tragedies.\nOne is not to get your heart’s desire;\nthe other is to get it.",
           "author": "George Bernard Shaw",
           "tag": []
         },
         {
-          "id": "2a864efe-ea88-4834-b965-953c63e50b44",
           "text": "Until you understand a writer's ignorance,\npresume yourself ignorant of his understanding.",
           "author": "Samuel Taylor Coleridge",
           "tag": []
         },
         {
-          "id": "79cb421f-1e13-4a8a-9650-73f860a16c53",
           "text": "If you presume to love something,\nyou must love the process of it much more than you love the finished product.",
           "author": "John Irving",
           "tag": []
         },
         {
-          "id": "430a145b-c6a5-4463-89cc-e8c331178df3",
           "text": "If you can walk with the crowd and keep your virtue,\nor walk with Kings- nor lose the common touch;\nIf neither foes nor loving friends can hurt you;\nIf all men count with you, but none too much;\nIf you can fill the unforgiving minute with 60 seconds worth of distance run-\nYours is the earth and everything that's in it,\nAnd- which is more- you'll be a man my son.",
           "author": "Rudyard Kipling",
           "tag": []
         },
         {
-          "id": "1c81c86e-a54c-4b05-befc-2a0b08cc3012",
           "text": "It's better to be a warrior in a garden than a gardener in a war.",
           "author": "Sun Tzu",
           "tag": []
         },
         {
-          "id": "4453f349-cf27-4d9b-a0db-76341c317066",
           "text": "fortis fortuna adiuvat\n_fortune favors the bold_",
           "author": null,
           "tag": []
         },
         {
-          "id": "0c73d976-9942-482a-83c0-1b29c8b23799",
           "text": "Never say never because limits,\nlike fears,\nare most often an illusion.",
           "author": "Michael Jordan",
           "tag": []
         },
         {
-          "id": "18088de8-3bba-4dcf-83cf-46af614c8737",
           "text": "Reading maketh a full man;\nspeaking a ready man;\nwriting, an exact man.",
           "author": "Francis Bacon",
           "tag": []
         },
         {
-          "id": "6736b6ec-a31e-46cc-abd3-f35033c78979",
           "text": "Do the difficult things while they are easy\nand do the great things while they are small.\nA journey of a thousand miles must begin with a single step.",
           "author": "Lao Tzu",
           "tag": []
         },
         {
-          "id": "9e02423a-8a36-4f81-9665-399b44bee092",
           "text": "When boiled:\n* a carrot gets softer\n* an egg gets harder\n* and coffee changes the water itself",
           "author": null,
           "tag": []
         },
         {
-          "id": "769b5aae-867d-487c-a437-67bbd0547910",
           "text": "The reasonable man adapts himself to the world;\nthe unreasonable one persists in trying to adapt the world to himself.\nTherefore, all progress depends on the unreasonable man.",
           "author": "George Bernard Shaw",
           "tag": []
         },
         {
-          "id": "697010bc-940c-4314-83f6-f43b526203e8",
           "text": "You can easily judge the character of a man by how he treats those who can do nothing for him.",
           "author": "Malcolm S. Forbes",
           "tag": []
         },
         {
-          "id": "f1140ff2-2f6e-4c57-8d10-f3d694f9080d",
           "text": "Where the spirit does not work with the hand there is no art.",
           "author": "Leonardo da Vinci",
           "tag": []
         },
         {
-          "id": "e2cab54a-6b0d-462e-86e2-33bbf8990e46",
           "text": "It is said that when Wesley and Whitefield were at odds on theology and ecclesiastical matters,\none of Wesley’s adherents asked him,\n“Do you think we shall see Mr. Whitefield in heaven?”\n“No,” he answered, “I do not.\nI think he will be so near the Throne, and you and I so far away,\nthat we shall not get within sight of him.”",
           "author": "G. B. Wilcox",
           "tag": []
         },
         {
-          "id": "a82977eb-2dd5-4d8e-9864-3a8271ef147f",
           "text": "He who knows not and knows not that he knows not is a fool; shun him.\nHe who knows not and knows that he knows not is ; teach him.\nHe who knows and knows not that he knows is asleep; wake him.\nHe who knows and knows that he knows is wise; follow him.",
           "author": "Arabic Proverb",
           "tag": []
         },
         {
-          "id": "d9c2e92a-d0cf-43b5-a84a-d87288143a27",
           "text": "The day soldiers stop bringing you their problems is the day you have stopped leading them.",
           "author": "Colin Powell",
           "tag": []
         },
         {
-          "id": "7f126365-d919-41cf-af4f-c589711c63a1",
           "text": "If they come for the innocent without stepping over your dead body, cursed be your religion and your life.",
           "author": "Dorothy Day",
           "tag": []
         },
         {
-          "id": "1a67ed96-ee02-4be3-bbd0-41030d46c64b",
           "text": "No Dad, no life\nKnow Dad, know life",
           "author": null,
           "tag": []
         },
         {
-          "id": "f9d3a2fa-855c-4cc5-a623-300932361c26",
           "text": "Give a man a fish and feed him for a day; teach a man to fish and feed him for a lifetime; teach him to teach others to fish - and you feed a nation.",
           "author": null,
           "tag": []
         },
         {
-          "id": "16e4e9a7-a509-41d4-afbd-8d0fa1608775",
           "text": "Honor is the amount of personal risk one undertakes to manifest their beliefs.",
           "author": null,
           "tag": []
         },
         {
-          "id": "476351a2-7216-443f-b38c-fa360017f015",
           "text": "Knowledge is a rumor until you have it in your body.",
           "author": null,
           "tag": []
         },
         {
-          "id": "7f0ea89f-2323-4668-9676-690afa60a042",
           "text": "If you want something you've never had, you have to do something you've never done.",
           "author": null,
           "tag": []
         },
         {
-          "id": "fad62cd4-ef8c-4815-9ee8-8765b54e930f",
           "text": "Good enough isn't.",
           "author": null,
           "tag": []
         },
         {
-          "id": "af9f97f9-b5db-40c3-9c9f-df22af5c785d",
           "text": "Whether you think you're good enough or not you're right.",
           "author": "re: Henry Ford",
           "tag": []
         },
         {
-          "id": "09d76833-7a11-4629-af88-e2e34c071589",
           "text": "Leadership itself is amoral; its outcome depends on the heart of the leader.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "d04572a6-4c84-4e2a-8506-737f281fdd08",
           "text": "Perfer et obdura, dolor hic tibi proderit olim.\nBe patient and tough; this pain will help you someday.",
           "author": "Ovid",
           "tag": []
         },
         {
-          "id": "cf0112b4-c41c-4812-8f9e-d203cf676ead",
           "text": "A sample size of you is not a population.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "9c87d638-6d76-4700-9a7b-088fe3d5194d",
           "text": "God doesn't worry when we struggle with sin; He worries when we stop.",
           "author": "Chris Murphy",
           "tag": []
         },
         {
-          "id": "20291968-c9ac-4554-aa57-c7fb2bbc61e4",
           "text": "The stock market has predicted 7 of the last 2 recessions.",
           "author": "reprise: George Soros",
           "tag": []
         },
         {
-          "id": "88e92668-b21e-4f57-9117-d153659e1b4d",
           "text": "Anyone can make a mistake, but the fool perseveres in error.",
           "author": "Cicero",
           "tag": []
         },
         {
-          "id": "df747fe6-11ba-48ad-a184-5be16f82a07e",
           "text": "The most improper job of any man, even saints (who at any rate were at least unwilling to take it on), is bossing other men.  Not one in a million is fit for it, and least of all those who seek the opportunity.",
           "author": "J.R.R. Tolkien",
           "tag": []
         },
         {
-          "id": "d39e952d-3c2a-4738-8245-f3d6af525d2e",
           "text": "Any political hack can sell his soul to get ahead;  A truly skilled politician can gain on the sale of the souls of others.",
           "author": null,
           "tag": []
         },
         {
-          "id": "117b0eb9-9a1c-435b-89ac-9a5266a24c34",
           "text": "Mon centre cède, ma droite recule, situation excellente, j'attaque.",
           "author": "Ferdinand Foch",
           "tag": []
         },
         {
-          "id": "295b81c3-2f15-427a-afdb-6a863a7db96d",
           "text": "The desire for preeminence is the death knell of usefulness.",
           "author": "Alistair Begg",
           "tag": []
         },
         {
-          "id": "29054257-4103-4c57-91e2-c190d200f66b",
           "text": "Whoever controls the past controls the present,\nwhoever controls the present controls the future.",
           "author": "George Orwell",
           "tag": []
         },
         {
-          "id": "2b0e653a-908b-401a-addb-bd1a3a726275",
           "text": "A grandfather talking to his young grandson tells the boy he has two wolves inside of him, struggling with each other:\nThe first is the wolf of peace, love and kindness.\nThe other is the wolf of fear, greed and hatred.\n\"Which wolf will win, grandfather?\" asks the boy.\nThe grandfather replied,  \"Whichever one you feed.\"",
           "author": null,
           "tag": []
         },
         {
-          "id": "a86a4854-8d40-452c-93b1-30bf1d0f5433",
           "text": "The person who says it cannot be done should not interrupt the person doing it.",
           "author": null,
           "tag": []
         },
         {
-          "id": "407ca80f-ed7a-43fb-a9e4-8b0b7699864b",
           "text": "Defeat is not failure but, rather, not to have tried.",
           "author": "re: George Woodberry",
           "tag": []
         },
         {
-          "id": "af2e0e43-ba62-4924-bc0a-6119da3f5d6b",
           "text": "Child, \"Does God really watch me?\"\nPastor, \"He loves you so much He can't take His eyes off of you.\"",
           "author": null,
           "tag": []
         },
         {
-          "id": "ecd2d100-0ae9-492f-877e-a6b060a19a3d",
           "text": "Do what you can with what you have where you are.",
           "author": null,
           "tag": []
         },
         {
-          "id": "7c03fe8f-7f2a-4ef7-ba8b-3e8c4cdcf480",
           "text": "God puts maggots in our lives to clean the wounds.",
           "author": null,
           "tag": []
         },
         {
-          "id": "38abab6a-7f92-4df7-b6b0-be6c69ab1e85",
           "text": "On a visit to the NASA space center, President Kennedy spoke to a man sweeping up in one of the buildings.\n\"What's your job here?\" asked Kennedy.\n\"Well Mr. President,\" the janitor replied, \"I'm helping to put a man on the moon\".",
           "author": null,
           "tag": []
         },
         {
-          "id": "ed359c23-dd14-4e35-90b3-08450234d961",
           "text": "A young fish swims up to an old fish, \"I'm looking for the ocean!\"\nThe old fish says, \"you're in it.\"\nThe young fish says, \"no, this is just water - I'm looking for the ocean!\"",
           "author": null,
           "tag": []
         },
         {
-          "id": "297f0271-3ed7-4ab4-b874-f9b177a1ceac",
           "text": "Read yourself full,\nSpeak yourself empty,\nWrite yourself clear;",
           "author": "Allistair Begg",
           "tag": []
         },
         {
-          "id": "5802c366-b509-4d37-946a-909173c86863",
           "text": "It doesn’t make sense to hire smart people and then tell them what to do; we hire smart people so they can tell us what to do.",
           "author": "Steve Jobs",
           "tag": []
         },
         {
-          "id": "02181f5c-6450-43ba-b889-df92b01f66ee",
           "text": "Love is not an emotion. It is a policy.",
           "author": "Hugh Bishop",
           "tag": []
         },
         {
-          "id": "b4bad026-c5c5-4183-9e6f-99f54970d38c",
           "text": "Democracy is the worst form of government, except for all the others.",
           "author": "Winston Churchill",
           "tag": []
         },
         {
-          "id": "56860b61-2eda-4d7a-9e30-10b560d322c3",
           "text": "On two occasions, I have been asked [by members of Parliament], \"Pray, Mr. Babbage, if you put into the machine wrong figures, will the right answers come out?\"\nI am not able to rightly apprehend the kind of confusion of ideas that could provoke such a question.",
           "author": "Charles Babbage",
           "tag": []
         },
         {
-          "id": "5a0b66b4-6525-4076-abc1-3d260707cbf2",
           "text": "We are now gods but for the wisdom.",
           "author": "Eric Weinstein",
           "tag": []
         },
         {
-          "id": "6f2bc3e5-40bb-47c8-9225-2195748478bf",
           "text": "A leader doesn't squeeze in what was left out, they draw out what was left in.",
           "author": "unk",
           "tag": []
         },
         {
-          "id": "9fcbef6f-46e4-4981-911c-411e67e2a5bd",
           "text": "Be uncommon amongst uncommon people.",
           "author": "David Goggins",
           "tag": []
         },
         {
-          "id": "f6d71dd5-d251-4d52-9283-ea2a3ccc843e",
           "text": "Tenacity is the quality you need to overcome your stupendous lack of good judgment.",
           "author": null,
           "tag": []
         },
         {
-          "id": "3ea9fdc3-7d6e-4822-b5e0-db98997127fb",
           "text": "When told that his vision would blow up Apple, Steve Jobs said, \"better we blow it up than someone else.\"",
           "author": null,
           "tag": []
         },
         {
-          "id": "57660b19-d1c7-4572-b320-41c458759fd8",
           "text": "Grace and glory differ very little;\nthe one is the seed, the other is the flower;\ngrace is glory militant, glory is grace triumphant.",
           "author": "Thomas Brooks",
           "tag": []
         },
         {
-          "id": "b7882c5c-c33b-45bb-8b62-f1cbf3a9785c",
           "text": "If you are neutral in situations of injustice, you have chosen the side of the oppressor.",
           "author": "Desmond Tutu",
           "tag": []
         },
         {
-          "id": "ee57d7a8-59be-4419-bb60-051b409ba49c",
           "text": "If an egg is broken by an outside force, life ends;\nIf an egg is broken by an inside force, life begins.",
           "author": null,
           "tag": []
         },
         {
-          "id": "ea8f6c37-d383-4518-b897-100f557dde67",
           "text": "A man is one who has learned to operate under the authority of Jesus Christ while carrying out responsible and legitimate leadership within the sphere of influence that God has placed him.",
           "author": "Tony Evans",
           "tag": []
         },
         {
-          "id": "3471e328-eff7-403e-81fd-e54e38985ac8",
           "text": "There are two hard problems in computing:\nautomatically synchronized and invalidating remote, caching storage,\nnaming things,\nand off-by-1 errors.",
           "author": "re: Phil Karlton, Leon Bambrick",
           "tag": []
         },
         {
-          "id": "7c7459db-fa6d-41df-9357-343022736ddd",
           "text": "The first step towards wisdom is to call things by their proper name.",
           "author": "Confucius",
           "tag": []
         },
         {
-          "id": "1ebfb4f3-95e8-4645-a759-4cdc9e4771a1",
           "text": "They know enough who know how to learn.",
           "author": "Henry Brooks Adams",
           "tag": []
         },
         {
-          "id": "636aeedf-c84e-4c4a-bcac-15893e8240c3",
           "text": "switching elements are modeled by quantum mechanics described by differential equations whose behavior is captured by numerical approximations represented in computer programs executing on computers composed of switching elements",
           "author": "Gerald Sussman",
           "tag": []
         },
         {
-          "id": "ecec3002-8ded-40d1-ad9d-0acdd2d3875b",
           "text": "\"Computer Science\" is not a science, and it's significance has little to do with computers.",
           "author": "Marvin Minsky",
           "tag": []
         },
         {
-          "id": "a37a03c8-71ee-4d84-b764-c0d5dce6adc7",
           "text": "I think computer science, by and large, is still stuck in the Modern Age.",
           "author": "Larry Wall",
           "tag": []
         },
         {
-          "id": "3fdfe483-25ea-4aa1-aed2-299481ac916e",
           "text": "In order to be great it isn't enough to be right - you must be great.",
           "author": "M. L'Engle",
           "tag": []
         },
         {
-          "id": "e6e7964a-c8f4-40f4-b443-e18f1f3edea7",
           "text": "There are three components to success: simplify, simplify, simplify.",
           "author": null,
           "tag": []
         },
         {
-          "id": "7fb7b411-b1ee-462f-8a0f-f7336e0fd9b4",
           "text": "The first gulp from the glass of natural sciences will make you an Atheist,\nbut at the bottom of the glass, God is waiting for you.",
           "author": "Werner Heisenberg",
           "tag": []
         },
         {
-          "id": "5082f47f-280a-4027-bba8-25c958ccb13a",
           "text": "Ex falso sequitur quodlibet.\n_from falsehood anything follows_.",
           "author": null,
           "tag": []
         },
         {
-          "id": "506db119-ae10-4f68-b4d9-051174cd664a",
           "text": "You feel things too deeply to bear them unless you can get them out of yourself through some sort of art.",
           "author": "Madeleine L'Engle",
           "tag": []
         },
         {
-          "id": "e8005fac-53c8-4a24-b3de-b8b22c615237",
           "text": "Upon review of the past year:\nI desire to confess that my unfaithfulness has been exceedingly great,\nmy sins still greater,\nGod's mercies greater than both.\nMy shortcomings and mis-doings,\nmy unbelief and want of love would sink me into the lowest hell,\nwas not Jesus my righteousness and my redeemer.",
           "author": "Augustus Toplady",
           "tag": []
         },
         {
-          "id": "03186ea9-b6e5-41e4-a8a4-cb2a536b1815",
           "text": "There isn't much traffic on the extra mile.",
           "author": "Henri Barber",
           "tag": []
         },
         {
-          "id": "38eac4a3-dd15-4468-a6f9-e3b215b7dd90",
           "text": "A design center should be equal parts monastery, pub, and sweatshop.",
           "author": "Ilse Crawford",
           "tag": []
         },
         {
-          "id": "f7a417a7-9c3e-41db-8736-6a82b0d7370b",
           "text": "Some have at first for wits, then poets passed,\nTurn’d critics next, and proved plain fools at last.",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "3c11a7d7-fba0-4283-ba26-9a411cb13d26",
           "text": "A man convinced against his will is of the same opinion still.",
           "author": null,
           "tag": []
         },
         {
-          "id": "6ac1001c-e94f-4d83-8538-73dd1c677457",
           "text": "The world is full of intellectual derelicts.",
           "author": "Calvin Coolidge",
           "tag": []
         },
         {
-          "id": "e74a563f-6b9b-4482-b086-87528d7573d4",
           "text": "I don't skate to where the puck is, I skate to where the puck is going to be.",
           "author": "Wayne Gretsky",
           "tag": []
         },
         {
-          "id": "48a01e12-64fb-4911-ab1b-7f915824c95a",
           "text": "Who are the people most opposed to escapism?  Jailors!",
           "author": "C.S. Lewis",
           "tag": []
         },
         {
-          "id": "a3de4915-b03e-4cfd-a32b-3a638953153c",
           "text": "When two partners always agree, one of them is not necessary.",
           "author": null,
           "tag": []
         },
         {
-          "id": "f4bd0da3-a61c-433a-8fd5-1f5f3f6fc0a8",
           "text": "The idea comes to me from outside of me - and is like a gift. I then take the idea and make it my own - that is where the skill lies.",
           "author": "Johannes Brahms",
           "tag": [
@@ -2096,259 +1758,216 @@
           ]
         },
         {
-          "id": "3d1601ed-4d22-4ea8-bf1a-bb4b21168088",
           "text": "There is a principle which:\nis a bar against all information,\nis a proof against all argument,\ncannot fail to keep man in everlasting ignorance;\ncondemnation before investigation.",
           "author": "Edmund Spencer",
           "tag": []
         },
         {
-          "id": "ec0c774c-6cf6-4380-971b-745f1991e8d7",
           "text": "Evidence for the conspiracy is evidence for the conspiracy.\nEvidence against the conspiracy is evidence for the conspiracy.",
           "author": "Stephen Novella",
           "tag": []
         },
         {
-          "id": "a6b3e43d-f508-4d79-825d-321ff09f6ef5",
           "text": "In necessariis unitas,\nin dubiis libertas,\nin omnibus caritas.",
           "author": "Rupertus Meldenius",
           "tag": []
         },
         {
-          "id": "23829366-c3a9-4bda-9914-02998ec584c9",
           "text": "Searching something unsorted is inefficient,\nsorting something never searched is a waste of time.",
           "author": null,
           "tag": []
         },
         {
-          "id": "d4f84973-44f8-4899-9adb-4e09ddd1b353",
           "text": "I am a revolutionary, so my son can be a farmer, so his son can be a poet.",
           "author": "John Adams",
           "tag": []
         },
         {
-          "id": "85366dfa-c363-45a6-8743-2e3b414813fd",
           "text": "The Spartans do not ask how many the enemies are but where they are.",
           "author": "Agis II",
           "tag": []
         },
         {
-          "id": "c9cbe4d7-0cca-4b29-a3c0-1cee9f193051",
           "text": "Si vis pacem, para bellum.",
           "author": "Plato via Publius Flavius",
           "tag": []
         },
         {
-          "id": "f90c8d68-e5ff-42ce-8df9-13e9a6f6bf95",
           "text": "Those people who will not be governed by God will be ruled by tyrants.",
           "author": "William Penn",
           "tag": []
         },
         {
-          "id": "763466a4-f7a0-48ba-9d96-e5e4e0b00a49",
           "text": "Somewhere a True Believer is training to kill you.\nHe is training with minimal food or water, in austere conditions, day and night.\nThe only thing clean on him is his weapon.\nHe doesn't worry about what workout to do - his ruck weighs what it weighs, his run ends when the enemy stops chasing him.\nThis True Believer is not concerned about 'how hard it is,' he either wins or dies.\nHe doesn't go home at 17:00, he is home.\nHe knows only The Cause.",
           "author": "Doc",
           "tag": []
         },
         {
-          "id": "d8fc67d7-1488-4d74-b73c-40ddd5dafb13",
           "text": "It is the soldier, not the reporter, who has given us Freedom of Press.\nIt is the soldier, not the poet, who has given us Freedom of Speech.\nIt is the soldier, not the campus organizer, who has given us the Freedom to Demonstrate.\nIt is the soldier, who salutes the flag, who serves beneath the flag, and whose coffin is draped by the flag that allows the protester to burn the flag.",
           "author": "Father Dennis O'Brien; Chaplain, USN",
           "tag": []
         },
         {
-          "id": "39b848b5-3e7e-4121-beff-75e372eceb54",
           "text": "In the beginning of a change, the patriot is a scarce man, brave, hated, and scorned.\nWhen his cause succeeds however, the timid join him, for then it costs nothing to be a patriot.",
           "author": "Mark Twain",
           "tag": []
         },
         {
-          "id": "889ad569-bfb8-4c2f-a75e-64703570be4a",
           "text": "A superior operator uses his superior judgement to keep himself out of situations that would require his superior skills.",
           "author": null,
           "tag": []
         },
         {
-          "id": "bffec1d8-8dd3-4ff8-8ed8-cf9084979581",
           "text": "A human being should be able to change a diaper, plan an invasion, butcher a hog, conn a ship, design a building, write a sonnet, balance accounts, build a wall, set a bone, comfort the dying, take orders, give orders, cooperate, act alone, solve equations, analyze a new problem, pitch manure, program a computer, cook a tasty meal, fight efficiently, die gallantly.  Specialization is for insects.",
           "author": "Robert A. Heinlein",
           "tag": []
         },
         {
-          "id": "c19cb11e-811f-437b-9a93-1deb298354b6",
           "text": "When the government's boot is on your throat, whether it is a left boot or a right boot is of no consequence.",
           "author": "Gary Lloyd",
           "tag": []
         },
         {
-          "id": "5f9589ec-5cab-487b-a8f5-43bce239620c",
           "text": "The difference between a warrior and an ordinary man is\na warrior sees everything as a challenge and an ordinary man sees it as a blessing or curse.",
           "author": "Don Juan",
           "tag": []
         },
         {
-          "id": "5262d7ed-fd24-48f9-88a7-a8a36f8d049f",
           "text": "We do not rise to the occassion, we fall to the level of our training.",
           "author": null,
           "tag": []
         },
         {
-          "id": "794189dc-fb54-4ca5-aa6b-15c15c2d747b",
           "text": "We are what we repeatedly do.  Excellence, then, is not an act but a habit.",
           "author": "Aristotle",
           "tag": []
         },
         {
-          "id": "e43f0fb4-c4ec-4306-afcf-94de9d27d4f2",
           "text": "When you go home tell them of us and say, 'for their tomorrow we gave our today'.",
           "author": "John Maxwell Edmonds",
           "tag": []
         },
         {
-          "id": "ac9b74e8-a56c-4539-b578-29811bfe7eec",
           "text": "The philosophy of the classroom today, will be the philosophy of the government tomorrow.",
           "author": "Abraham Lincoln",
           "tag": []
         },
         {
-          "id": "3321917b-b69f-4cfa-8c4f-b63841887ed0",
           "text": "If there must be trouble, let it be in my day that my children may have peace.",
           "author": "Thomas Paine",
           "tag": []
         },
         {
-          "id": "66f51dd7-2776-43e6-90f9-899d68a8ab91",
           "text": "We must, indeed, all hang together or, most assuredly, we shall all hang separately.",
           "author": "Ben Franklin",
           "tag": []
         },
         {
-          "id": "0f8013f8-1566-411b-9595-2e6b3f0f453b",
           "text": "Let us speak courteously, deal fairly, and keep ourselves armed and ready.",
           "author": "Theodore Roosevelt",
           "tag": []
         },
         {
-          "id": "e7bdcdb8-9820-4dfb-8b00-54827860931b",
           "text": "Food for the body is not enough.\nThere must be food for the soul.",
           "author": "Dorothy Day",
           "tag": []
         },
         {
-          "id": "0efa99b5-682e-49af-9419-77f976b3a60d",
           "text": "Among the many misdeeds of the British rule in India, history will look upon the Act depriving a whole nation of arms, as the blackest.",
           "author": "Mahatma Gandhi",
           "tag": []
         },
         {
-          "id": "0cb29551-5afb-4e1c-9e8a-d5249158ec9a",
           "text": "Even if you are a minority of one, the truth is the truth.",
           "author": "Mahatma Gandhi",
           "tag": []
         },
         {
-          "id": "92dda503-1bb6-4773-b153-c4b20715116b",
           "text": "Everything should be made as simple as possible, but not simpler.",
           "author": "Albert Einstein",
           "tag": []
         },
         {
-          "id": "08241795-8d2e-4370-875e-31f374c498e8",
           "text": "The weak can never forgive.\nForgiveness is an attribute of the strong.",
           "author": "Mahatma Gandhi",
           "tag": []
         },
         {
-          "id": "b3f9a3bb-2895-4a96-b5b2-3f85c5a2c934",
           "text": "The United States has sent many of its fine young men and women into great peril to fight for freedom beyond our borders.\nThe only amount of land we have ever asked for is enough to bury those that did not return.",
           "author": "Colin Powell",
           "tag": []
         },
         {
-          "id": "68d611be-4972-4c45-8204-1b3dc01e302e",
           "text": "Teach your children the art of war, so that they may teach their children math and science, and their children can study art and literature.",
           "author": "John Adams, 2nd President of the United States",
           "tag": []
         },
         {
-          "id": "2c4b97b4-b2b8-432b-87fe-baba094dec41",
           "text": "Those who sacrifice essential liberty for temporary safety are not deserving of either liberty or safety.",
           "author": "Benjamin Franklin",
           "tag": []
         },
         {
-          "id": "51c6da37-dc48-4392-9d43-b5687333074d",
           "text": "Nothing in Scripture depicts the Christian life as divided into sacred and secular parts.",
           "author": "Dan Miller",
           "tag": []
         },
         {
-          "id": "ce8e7b95-f375-4b86-8572-a2cab9a19000",
           "text": "If your attack is going too well, you're probably walking into an ambush.",
           "author": "Infantry Journal",
           "tag": []
         },
         {
-          "id": "20366d88-10f6-4d64-987b-afd656b39e29",
           "text": "Divide et Impera\nDivide ut Regnes",
           "author": null,
           "tag": []
         },
         {
-          "id": "be0d9c7d-d5d0-4461-a5dd-90d94a60ce07",
           "text": "There are four boxes to be used in the defense of liberty: soap, ballot, jury and ammo.\nPlease use in that order.",
           "author": "Larry McDonald",
           "tag": []
         },
         {
-          "id": "7e67f18e-d1a6-4896-a4c0-056f48679961",
           "text": "The democracy will cease to exist when you take away from those who are willing to work and give to those who would not.",
           "author": "Thomas Jefferson",
           "tag": []
         },
         {
-          "id": "5fcb2656-d135-430e-912a-23ea5f1c375b",
           "text": "The strongest reason for the people to retain the right to keep and bear arms is, as a last resort, to protect themselves against tyranny in government.",
           "author": "Thomas Jefferson",
           "tag": []
         },
         {
-          "id": "de023d9c-0aae-47b2-a49b-3553d16b551e",
           "text": "Drills teach principles.  They teach ideas.  They are the map, not the territory.",
           "author": "MM",
           "tag": []
         },
         {
-          "id": "f2750f28-e5a4-4763-bed6-990de4777864",
           "text": "Life should not be a journey to the grave with the intention of arriving safely in a pretty and well preserved body,\nbut rather to skid in broadside, thoroughly used up, totally worn out, and loudly proclaiming --WOW-- What a ride!",
           "author": "Burke",
           "tag": []
         },
         {
-          "id": "38e066e8-daa7-486b-978e-00a42c2f37c1",
           "text": "The beauty of the Second Amendment is that it will not be needed until they try to take it.",
           "author": "Thomas Jefferson",
           "tag": []
         },
         {
-          "id": "b0102732-bb83-44f9-ac8e-e55495632c5d",
           "text": "Gun Control: the theory that a woman found dead in an alley, raped, and strangled with her own pantyhose, is somehow morally superior to a woman explaining to police how her attacker got that fatal bullet wound.",
           "author": "L. Neil Smith",
           "tag": []
         },
         {
-          "id": "0571b813-f8a9-4f1b-8aef-2eab63f8331b",
           "text": "People sleep peacefully in their beds at night only because rough men stand ready to do violence on their behalf.",
           "author": "George Orwell",
           "tag": []
         },
         {
-          "id": "1ba9a4ba-1cb1-4a29-8fc3-8ddf9c5b918a",
           "text": "If you come expecting a fair fight, you are unprepared.",
           "author": null,
           "tag": []
         },
         {
-          "id": "7dff9818-3ca9-43c1-81ed-a0b39ab6c238",
           "text": "To compel a man to furnish contributions of money for the propagation of opinions which he disbelieves and abhors, is sinful and tyrannical.",
           "author": "Thomas Jefferson",
           "tag": [
@@ -2361,7 +1980,6 @@
           ]
         },
         {
-          "id": "80334409-d8cf-4fbf-a0f2-00b0ebea48e7",
           "text": "It is not hard to compose, but what is fabulously hard is to leave the superfluous notes under the table.",
           "author": "Johannes Brahms",
           "tag": [
@@ -2376,7 +1994,6 @@
           ]
         },
         {
-          "id": "6ddcce7e-a6e6-4271-9dcd-d83a8c0a077c",
           "text": "I am thus far a Quaker, that I would gladly argue with all the world to lay aside the use of arms and settle matters by negotiation,\nbut unless the whole will, the matter ends, and I take up my musket and thank Heaven He has put it in my power.",
           "author": "Thomas Paine",
           "tag": [
@@ -2389,7 +2006,6 @@
           ]
         },
         {
-          "id": "6d2dd7d5-3201-4793-8a4c-418420afeda4",
           "text": "The only way to secure the freedom of a nation is to have a great army in time of peace.",
           "author": "Napoleon Bonaparte",
           "tag": [
@@ -2402,37 +2018,31 @@
           ]
         },
         {
-          "id": "de0f0e61-83f3-4949-95c9-5781f462a702",
           "text": "I am concerned for the security of our great nation, not so much because of any threat from without,\nbut because of the insidious forces working from within.",
           "author": "General Douglas MacArthur",
           "tag": []
         },
         {
-          "id": "08fa42a9-a431-4638-b779-543779360a29",
           "text": "Those who expect to reap the blessings of freedom must, like men, undergo the fatigue of supporting it.",
           "author": "Thomas Paine",
           "tag": []
         },
         {
-          "id": "c616c64a-38d9-4022-9576-f24549b67f43",
           "text": "Our freedom is not being destroyed by terrorists, but by ignorance, apathy and complacency.\nOur government schools are to blame...Our dumbing down is not accidental but a very well organized plan.",
           "author": "Kelly McGinley",
           "tag": []
         },
         {
-          "id": "1575f390-23e4-4bff-915f-352930ace533",
           "text": "If God does not punish America, He should apologize to Sodom & Gommorrah.",
           "author": "Billy Graham",
           "tag": []
         },
         {
-          "id": "df313231-6a7b-46fe-8d7e-1c7a2d096e5b",
           "text": "Democracy is two wolves and a lamb discussing what's for dinner.\nLiberty is a well armed lamb willing to contest the majority decision.",
           "author": "Benjamin Franklin",
           "tag": []
         },
         {
-          "id": "af680b76-e6c4-427f-8b40-e14506b46ad1",
           "text": "Reviewer: 'One of your themes was very similar to one of Beethoven's!' Brahms replied, 'Of course it is. Everyone steals - the important thing is to do it brilliantly.",
           "author": "Johannes Brahms",
           "tag": [
@@ -2446,421 +2056,351 @@
           ]
         },
         {
-          "id": "df2c9136-2f4b-4457-8c08-da060bef3c78",
           "text": "Every normal man must be tempted at times to spit on his hands, hoist the black flag, and begin to slit throats.",
           "author": "H.L. Mencken",
           "tag": []
         },
         {
-          "id": "d4f0d908-9f5a-4cd3-bca8-8ca295dbe383",
           "text": "A man with a toothache cannot be in love.",
           "author": "Shakespeare",
           "tag": []
         },
         {
-          "id": "680351a4-bf03-43df-b0d5-d08df5f9b4b6",
           "text": "Ever tried.  Ever failed.  No matter.\nTry again.  Fail again.  Fail better.",
           "author": "Samuel Beckett",
           "tag": []
         },
         {
-          "id": "4eaf8835-8206-4270-9c63-e90b43c0f939",
           "text": "After each of our wars, there has always been a great hue and cry to the effect that...by removing the fire department, we will remove fires.",
           "author": "George S. Patton",
           "tag": []
         },
         {
-          "id": "c3fa11d6-20c3-4c99-8ded-47b9c9946ae2",
           "text": "I do not say that there will be no more wars; I devoutly hope that there will not, but I do say that the chances of avoiding future wars will be greatly enhanced if we are ready.",
           "author": "George S. Patton",
           "tag": []
         },
         {
-          "id": "2d63896d-5ac3-4a62-851c-eae37a24fc29",
           "text": "A veteran - whether active duty, retired, national guard, or reserve - is someone who, at one point in his or her life, wrote a blank check made payable to The 'United States of America', for an amount of 'up to and including his life.'",
           "author": "Author Unknown",
           "tag": []
         },
         {
-          "id": "b6ede829-4491-40ff-846a-d916399310f7",
           "text": "It is incumbent on every generation to pay its own debts as it goes.  A principle which if acted on would save one-half the wars of the world.",
           "author": "Thomas Jefferson",
           "tag": []
         },
         {
-          "id": "490af2e8-399a-4d06-8658-0d9ee542cb36",
           "text": "I predict future happiness for Americans if they can prevent the government from wasting the labors of the people under the pretense of taking care of them.",
           "author": "Thomas Jefferson",
           "tag": []
         },
         {
-          "id": "120d2438-bca8-44a7-a6a9-d7c4704b02fe",
           "text": "My reading of history convinces me that most bad government results from too much government.",
           "author": "Thomas Jefferson",
           "tag": []
         },
         {
-          "id": "bbba6441-ba98-47d9-b843-1b1da1db784a",
           "text": "I would never invade the United States.  There would be a gun behind every blade of grass.",
           "author": "Isoroku Yamamoto",
           "tag": []
         },
         {
-          "id": "5a74ea70-ea31-4691-a191-60c65835e22c",
           "text": "Sell not virtue to purchase wealth, nor Liberty to purchase power.",
           "author": "Benjamin Franklin",
           "tag": []
         },
         {
-          "id": "35b4c083-7bea-46a9-b1c2-3610114ea357",
           "text": "If guns kill people, then:\npencils miss spel words,\ncars make people drive drunk,\nand spoons make people fat.",
           "author": "GOOA",
           "tag": []
         },
         {
-          "id": "941a108d-cbb4-4613-9915-1ac3d7d57448",
           "text": "My tone is a direct reflection of your attitude.",
           "author": null,
           "tag": []
         },
         {
-          "id": "6ce61c7f-3545-4350-b210-db80d6846a50",
           "text": "An armed man is a citizen.  An unarmed man is a subject.",
           "author": null,
           "tag": []
         },
         {
-          "id": "00fab172-3167-4e2e-bf61-a1291fcd59aa",
           "text": "A gun in the hand is better than a cop on the phone.",
           "author": null,
           "tag": []
         },
         {
-          "id": "2d2692fc-d6d1-4754-a56c-7495b4b81f03",
           "text": "Gun control is not about guns; it's about control.",
           "author": null,
           "tag": []
         },
         {
-          "id": "8e1aba3c-ff61-4002-a40a-24e8f5f500ac",
           "text": "If guns cause crime, then cameras cause pornography.",
           "author": null,
           "tag": []
         },
         {
-          "id": "ef7d23f6-7a7a-4a51-8b35-2c30fd8d258b",
           "text": "Free men do not have to ask permission to bear arms.",
           "author": null,
           "tag": []
         },
         {
-          "id": "1656a099-28f3-43d7-94ba-0bbd2869b373",
           "text": "If you don't know your rights you don't have any.",
           "author": null,
           "tag": []
         },
         {
-          "id": "93e70d32-1964-49ed-a790-3230fc07493e",
           "text": "Guns only have two enemies: rust and liberals.",
           "author": null,
           "tag": []
         },
         {
-          "id": "f7d76717-7924-4d72-8f52-0695b0c7fb0e",
           "text": "Know guns, know peace and safety.  No guns, no peace nor safety.",
           "author": null,
           "tag": []
         },
         {
-          "id": "795c3156-1ee8-4e94-b83e-63fa3b2383a5",
           "text": "Assault is a type of behavior, not a type of hardware.",
           "author": null,
           "tag": []
         },
         {
-          "id": "a28f5efc-a07b-4756-bda5-64b56b2d87de",
           "text": "Criminals love gun control, it makes their jobs easier and safer.",
           "author": null,
           "tag": []
         },
         {
-          "id": "7d29158d-98fc-45aa-b32e-b9aed1ba0529",
           "text": "The American Revolution wasn't about tea and taxes.  It was about taking guns!",
           "author": null,
           "tag": []
         },
         {
-          "id": "da1ebc68-aa5b-4779-8b50-b11d6734bce0",
           "text": "The pen is mightier than the sword, unless you are in a swordfight!",
           "author": null,
           "tag": []
         },
         {
-          "id": "a8991436-a1d3-4e6b-8742-de0fae9db672",
           "text": "Those who live by the sword have a fighting chance.",
           "author": null,
           "tag": []
         },
         {
-          "id": "45dbb0bb-3e8c-448b-ba05-601002ede7b4",
           "text": "My gun?  I'd rather have it and not need it than need it and not have it.",
           "author": null,
           "tag": []
         },
         {
-          "id": "5454786a-2850-4259-a1c2-35d70bbc8122",
           "text": "Firearm safety is a matter for education, not legislation.",
           "author": null,
           "tag": []
         },
         {
-          "id": "9abd33a5-ea80-45b2-9057-4630add79ccc",
           "text": "An armed society is a polite society.",
           "author": null,
           "tag": []
         },
         {
-          "id": "4657736c-65b3-46fd-995d-5882720e831f",
           "text": "How can you praise freedom, and condemn that which gains and preserves it?",
           "author": null,
           "tag": []
         },
         {
-          "id": "90fa2e16-0756-4ee7-8d60-6ee4567488e7",
           "text": "My wife and my gun: 'til death do us part.",
           "author": null,
           "tag": []
         },
         {
-          "id": "767a433a-6665-4315-a165-b9a688c97aed",
           "text": "When they come for your guns, give them the ammo first!",
           "author": null,
           "tag": []
         },
         {
-          "id": "461aed5d-1092-44ad-89d4-9240640395b4",
           "text": "When seconds count, the cops are just minutes away...",
           "author": null,
           "tag": []
         },
         {
-          "id": "249a702f-98c9-4577-aa46-e28ff3706986",
           "text": "Writing is not necessarily something to be ashamed of, but do it in private and wash your hands when you're done.",
           "author": "Robert Heinlein",
           "tag": []
         },
         {
-          "id": "4a26260c-35bd-48d6-8a16-2963b173c54c",
           "text": "A good speech should be like a woman's skirt; long enough to cover the subject and short enough to create interest.",
           "author": "Winston Churchill",
           "tag": []
         },
         {
-          "id": "32c95383-8fcb-4031-87f0-01a230755c9a",
           "text": "I must not fear.  Fear is the mind-killer.  Fear is the little-death that brings total obliteration.  I will face my fear.  I will permit it to pass over me and through me.  And when it has gone past I will turn the inner eye to see its path.  Where the fear has gone there will be nothing.  Only I will remain.",
           "author": "Bene Gesserit 'Litany Against Fear,'",
           "tag": []
         },
         {
-          "id": "03759549-bfb5-4a81-8d99-45415abefb4e",
           "text": "Night gathers, and now my watch begins.  It shall not end until my death.  I shall take no wife, hold no lands, father no children.  I shall wear no crowns and win no glory.  I shall live and die at my post.  I am the sword in the darkness.  I am the watcher on the walls.  I am the fire that burns against the cold, the light that brings the dawn, the horn that wakes the sleepers, the shield that guards the realms of men.  I pledge my life and honor to the Night's Watch, for this night and all the nights to come.",
           "author": "George R.R. Martin, oath of the night's watch",
           "tag": []
         },
         {
-          "id": "9e8bebd7-ece1-4a7b-9064-305704890325",
           "text": "The crystal is the heart of the blade.\nThe heart is the crystal of the Jedi.\nThe Jedi is the crystal of the Force.\nThe Force is the blade of the heart.",
           "author": null,
           "tag": []
         },
         {
-          "id": "2bf0faca-114d-43bd-a77a-6ca7e382cd58",
           "text": "Absorb what is useful, discard what is useless, and add what is uniquely your own.",
           "author": "Bruce Lee",
           "tag": []
         },
         {
-          "id": "b4bf4e2d-e754-446b-ad46-ca776b278206",
           "text": "ὦ ξεῖν', ἀγγέλλειν Λακεδαιμονίοις ὅτι τῇδε κείμεθα τοῖς κείνων ῥήμασι πειθόμενοι.",
           "author": "the Cenotaph of Thermopylae",
           "tag": []
         },
         {
-          "id": "6d0dc768-2905-410b-bcc6-d9f3745db394",
           "text": "Programs must be written for people to read, and only incidentally for machines to execute.",
           "author": "H.Abelson & G.Sussman",
           "tag": []
         },
         {
-          "id": "fee8b44d-1193-4b15-8b86-610c4d6e3c49",
           "text": "A common mistake people make when trying to design something completely foolproof is to underestimate the ingenuity of complete fools.",
           "author": "D.Adams",
           "tag": []
         },
         {
-          "id": "9c100c96-dea7-4013-91f1-87d9230289b0",
           "text": "Don't worry about people stealing your ideas. If your ideas are any good, you'll have to ram them down people's throats.",
           "author": "H. Aiken",
           "tag": []
         },
         {
-          "id": "dba0727b-45b0-4a6d-93e4-4cc4c30bb6d0",
           "text": "Good teaching is more a giving of the right questions than a giving of the right answers.",
           "author": "J. Albers",
           "tag": []
         },
         {
-          "id": "1efc6693-2ace-4a21-aca8-e21cd5d4f223",
           "text": "The absence of floods is drought, the impossibility of weeds is famine.",
           "author": "The Monk, Diablo 3",
           "tag": []
         },
         {
-          "id": "1f9b3785-82aa-4486-b108-8f05fa8e64b2",
           "text": "Scientists, like many others, are touched with awe at the order and complexity of nature.\nIndeed, many scientists are deeply religious.\nBut science and religion occupy two separate realms of human experience.\nDemanding that they be combined detracts from the glory of each.",
           "author": "Bruce Alberts",
           "tag": []
         },
         {
-          "id": "6377547c-eec7-4e7c-94bb-816394f79290",
           "text": "The most exciting phrase to hear in science - the one that heralds new discoveries - is not \"Eureka!\" but \"That's funny...\".",
           "author": "Isaac Asimov",
           "tag": []
         },
         {
-          "id": "8c08d131-6ce0-4c7e-939a-cf16acfbd749",
           "text": "A prudent question is one-half of wisdom.",
           "author": "Francis Bacon",
           "tag": []
         },
         {
-          "id": "73968fe2-c916-4158-ad79-8617ac58ab3e",
           "text": "The sole justification of teaching, of the school itself, is that the student comes out of it able to do something he could not do before.\nI say do and not know, because knowledge that doesn't lead to doing something new or doing something better is not knowledge at all.",
           "author": "J. Barzun",
           "tag": []
         },
         {
-          "id": "0ec769bc-baa2-429a-a3bf-48659c9a69d5",
           "text": "The key to performance is elegance, not batallions of special cases.",
           "author": "J. Bently & D. McIlroy",
           "tag": []
         },
         {
-          "id": "72414f9a-2330-4f7c-870b-c8d8978feb60",
           "text": "Coming together is a beginning; keeping together is progress; working together is success.",
           "author": "Henry Ford",
           "tag": []
         },
         {
-          "id": "ca5b4265-7180-4d07-ae9f-54f02b387fc3",
           "text": "If there is any one secret of success, it lies in the ability to get the other person’s point of view and see things from that person’s angle as well as from your own.",
           "author": "Henry Ford",
           "tag": []
         },
         {
-          "id": "8b301e5f-be6d-4f6f-891a-07de9b112442",
           "text": "Walking on water and developing software from a specification are easy if both are frozen.",
           "author": "E. Berard",
           "tag": []
         },
         {
-          "id": "4effdee7-1d93-4d45-933f-822429f24090",
           "text": "Opposites are not contradictory but complementary.",
           "author": "Neils Bohr",
           "tag": []
         },
         {
-          "id": "fe4c2c83-67fc-458c-8c16-cc18088fc7d3",
           "text": "About the only real power a CEO or Chairman has is giving motivational speeches, approving budgets, and moving names around on an org chart.",
           "author": "Michael Hayden",
           "tag": []
         },
         {
-          "id": "7099ebff-3d95-4f3c-b722-2336b96b24d5",
           "text": "All programmers are playwrights and all computers are lousy actors.",
           "author": null,
           "tag": []
         },
         {
-          "id": "0da85ecd-9fc0-4b12-8177-a16094965581",
           "text": "Any programming problem can be solved by adding a level of indirection. (also see \"Any performance problem...\".)",
           "author": "M. Haertel",
           "tag": []
         },
         {
-          "id": "30a8867a-297f-4c39-bcec-e290f08fa37a",
           "text": "Experience is a poor teacher: it gives its tests before it teaches its lessons.",
           "author": null,
           "tag": []
         },
         {
-          "id": "81d505ff-a341-4866-b42a-312420ca3b8f",
           "text": "Given 8 hours to chop down a tree, spend 6 hours sharpening the axe.",
           "author": null,
           "tag": []
         },
         {
-          "id": "9142d15e-56cf-4039-bcdd-d3330abf4f0a",
           "text": "In theory, there is no difference between theory and practice, but not in practice.",
           "author": "Yogi Berra",
           "tag": []
         },
         {
-          "id": "a9d98a04-1976-4ed4-a151-e1bb85db1e52",
           "text": "If it doesn't fit, force it... If it breaks, it needed replacing anyway.",
           "author": null,
           "tag": []
         },
         {
-          "id": "7dd2928e-465b-4db1-a42d-50ea36f07c86",
           "text": "Measure twice, cut once.",
           "author": null,
           "tag": []
         },
         {
-          "id": "d0186f23-bfbe-40ce-a778-a33161ab4c91",
           "text": "One boy is half a man, two boys is a half a boy, and three boys ain't no help at all.",
           "author": "Lucius Currier",
           "tag": []
         },
         {
-          "id": "4081cfc7-4401-467a-a7a8-0fa64a288fe7",
           "text": "One day a mother comes home from work and asks her son, \"What did you do today?\" The son replied, \"I taught our dog how to play the piano.\"\nThe mother, incredulous, asked, \"Our dog can play the piano?\",\nto which the son laughed and replied, \"Of course not mom.  I said that I taught him; I didn't say that he learned how.\"",
           "author": null,
           "tag": []
         },
         {
-          "id": "b17a64d8-b568-404a-80d2-36adb8e3763a",
           "text": "The person who knows HOW will always have a job.\nThe person who knows WHY will always be his/her boss.",
           "author": null,
           "tag": []
         },
         {
-          "id": "5c2afdb9-892c-4150-8b92-136705d44304",
           "text": "There are 10 different kinds of people in the world: those who know binary and those who don't.",
           "author": null,
           "tag": []
         },
         {
-          "id": "be01ebf0-01f2-4f4b-a0ce-b1edc132dd31",
           "text": "Time is an excellent teacher; but eventually it kills all its students.",
           "author": null,
           "tag": []
         },
         {
-          "id": "ba3c445b-4b64-4904-bf47-dde71b41a47a",
           "text": "When a programming language is created that allows programmers to program in simple English, it will be discovered that programmers cannot speak English.",
           "author": null,
           "tag": []
         },
         {
-          "id": "af45f3e4-a47f-4ff1-9802-595bae3f1851",
           "text": "Perfectly written code is self-documenting.\nWhich is why all code should contain comments.",
           "author": "@",
           "tag": []
         },
         {
-          "id": "2ce61f2f-702b-40c6-b814-e8f5b2b29e4a",
           "text": "If we cannot write with the beauty of Mozart, let us at least try to write with his purity.",
           "author": "Johannes Brahms",
           "tag": [
@@ -2874,47 +2414,39 @@
           ]
         },
         {
-          "id": "bf28c4b5-472a-4c18-bf56-6268dc680bca",
           "text": "The best way to learn a new programming language is by writing programs in it."
         },
         {
-          "id": "769f35f7-4c2a-4584-9642-8cf4fcc4e25d",
           "text": "He who asks is a fool for five minutes; he who does not ask remains a fool forever.",
           "author": null,
           "tag": []
         },
         {
-          "id": "7790f0c1-3f2b-4274-bdef-a9456293534e",
           "text": "Life is painted on too big a canvas.",
           "author": null,
           "tag": []
         },
         {
-          "id": "1f40bebe-9074-4893-9ea2-3deee80fc216",
           "text": "If my answers frighten you then you should cease asking scary questions.",
           "author": "Quentin Tarantino",
           "tag": []
         },
         {
-          "id": "18e0b52e-0bfa-47be-951c-b8dc4b405101",
           "text": "I don't think there's anything to be afraid of. Failure brings great rewards - in the life of an artist.",
           "author": "Quentin Tarantino",
           "tag": []
         },
         {
-          "id": "22501285-cc37-4bbe-884f-d11e765bcb0e",
           "text": "Just because you are a character doesn't mean you have character.",
           "author": "Quentin Tarantino",
           "tag": []
         },
         {
-          "id": "cd32fb33-3fdc-41eb-a753-f75cc8df2bec",
           "text": "If you want to make a movie, make it. Don't wait for a grant, don't wait for the perfect circumstances, just make it.",
           "author": "Quentin Tarantino",
           "tag": []
         },
         {
-          "id": "51612346-8dcd-44c1-8f89-22a98e379b6b",
           "text": "Don't write what you think people want to read. Find your voice and write about what's in your heart.",
           "author": "Quentin Tarantino",
           "tag": [
@@ -2923,31 +2455,26 @@
           ]
         },
         {
-          "id": "8ce4c9e8-4ae9-4828-a423-b9d9c4a93a68",
           "text": "If a Million People See My Movie, I Hope They See a Million Different Movies.",
           "author": "Quentin Tarantino",
           "tag": []
         },
         {
-          "id": "9e491cdd-0beb-4d83-87e8-d0941ea1570a",
           "text": "The easiest way to kill a cult is to make that cult accessible.",
           "author": "Quentin Tarantino",
           "tag": []
         },
         {
-          "id": "139d00ba-f124-4314-b234-8168ae3e6b9c",
           "text": "I didn't go to film school, I went to films.",
           "author": "Quentin Tarantino",
           "tag": []
         },
         {
-          "id": "dc36271a-0217-4e45-beca-ac60e9242e65",
           "text": "I only write when the muse strikes.  Luckily the muse strikes everyday at 9am.",
           "author": "",
           "tag": []
         },
         {
-          "id": "0771ecd5-99d7-4698-86fc-80564a1e7bf5",
           "text": "An optimist says the glass is half-full; a pessimist says the glass is half-empty;  an engineer says the glass is twice as big as it needs to be.",
           "author": "",
           "tag": [

--- a/app/src/db.ts
+++ b/app/src/db.ts
@@ -5,6 +5,10 @@ import cloudConfig from '../dexie-cloud.json';
 export const PUBLIC_REALM_ID = 'rlm-public';
 
 export interface Quote {
+  /**
+   * Primary key. This is automatically assigned by Dexie Cloud, so
+   * new quotes should be added without specifying this property.
+   */
   id?: string;
   text: string;
   author: string | null;


### PR DESCRIPTION
## Summary
- Remove manual `id` values from seeded quote data so Dexie Cloud can assign primary keys
- Document that quote IDs are managed automatically by Dexie Cloud

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c44749712c832783283d10793df468