### PR TITLE
Filter live quotes to public and own

### DIFF
--- a/app/src/com/QuotesList.tsx
+++ b/app/src/com/QuotesList.tsx
@@ -24,7 +24,13 @@ function QuotesList({ loggedIn }: Props) {
       liveQuery?: typeof dexieLiveQuery;
     };
     const liveQuery = cloud.liveQuery ?? dexieLiveQuery;
-    const sub = liveQuery(() => db.quotes.toArray()).subscribe({
+    const sub = liveQuery(async () => {
+      const userId = db.cloud.currentUser.value.userId;
+      const qs = await db.quotes.toArray();
+      return qs.filter(
+        (q) => q.realmId === PUBLIC_REALM_ID || (userId && q.owner === userId),
+      );
+    }).subscribe({
       next: (qs: Quote[]) => setQuotes(qs),
       error: (err: unknown) => console.error('Failed to load quotes', err),
     });

--- a/app/src/db.ts
+++ b/app/src/db.ts
@@ -15,6 +15,8 @@ export interface Quote {
   tag: string[];
   /** Dexie Cloud realm identifier */
   realmId?: string;
+  /** Dexie Cloud owner identifier */
+  owner?: string;
 }
 
 export class ManthraDB extends Dexie {


### PR DESCRIPTION
## Summary
- include quote owner in the quote type so ownership is trackable
- filter live quote query to show only public realm quotes and the current user's own entries

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c467de27f08327941ed6aac56dd4f2