### PR TITLE
Handle public quotes without realmId

### DIFF
--- a/app/src/com/QuotesList.tsx
+++ b/app/src/com/QuotesList.tsx
@@ -28,7 +28,9 @@ function QuotesList({ loggedIn }: Props) {
       const userId = db.cloud.currentUser.value.userId;
       const qs = await db.quotes.toArray();
       return qs.filter(
-        (q) => q.realmId === PUBLIC_REALM_ID || (userId && q.owner === userId),
+        (q) =>
+          (q.realmId ?? PUBLIC_REALM_ID) === PUBLIC_REALM_ID ||
+          (userId && q.owner === userId),
       );
     }).subscribe({
       next: (qs: Quote[]) => setQuotes(qs),


### PR DESCRIPTION
## Summary
- Treat quotes with no realm assignment as public

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c469cc925c8327bf27fb917bc5212e