### PR TITLE
Add quote management modal with import and export

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import Footer from '@/com/Footer'
 import QuoteList from '@/com/QuoteList'
 
@@ -6,8 +5,6 @@ import '@/App.css'
 
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return <>
     <header>manthra</header>
 

--- a/app/src/com/Footer.jsx
+++ b/app/src/com/Footer.jsx
@@ -1,12 +1,51 @@
-import React from 'react'
+import React, {useRef, useState} from 'react'
+import QuoteUpsert from '@/com/QuoteUpsert'
+import {db} from '@/db/conx.js'
 
 
 export default function Footer() {
+  const [showUpsert, setShowUpsert] = useState(false)
+  const fileInput = useRef(null)
+
+  const handleImport = async event => {
+    const file = event.target.files?.[0]
+    if (!file) return
+    try {
+      const text = await file.text()
+      const quotes = JSON.parse(text)
+      if (Array.isArray(quotes)) {
+        await db.quotes.bulkPut(quotes)
+      }
+    } catch (err) {
+      console.error('Import failed', err)
+    } finally {
+      event.target.value = ''
+    }
+  }
+
+  const handleExport = async () => {
+    const quotes = await db.quotes.toArray()
+    const blob = new Blob([JSON.stringify(quotes, null, 2)], {type: 'application/json'})
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'quotes.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
   return <footer>
     &copy; 2024 fingerskier
 
-    <button>Add a Quote</button>
+    <button onClick={() => setShowUpsert(true)}>Add a Quote</button>
+
+    <button onClick={() => fileInput.current?.click()}>Import</button>
+    <input type="file" accept="application/json" ref={fileInput} style={{display: 'none'}} onChange={handleImport} />
+
+    <button onClick={handleExport}>Export</button>
 
     <button>Login</button>
+
+    <QuoteUpsert open={showUpsert} onClose={() => setShowUpsert(false)} />
   </footer>
 }

--- a/app/src/com/QuoteList.jsx
+++ b/app/src/com/QuoteList.jsx
@@ -10,6 +10,8 @@ export default function QuoteList() {
     {quotes && quotes.map(quote =>
       <li key={quote.id}>
         <blockquote>"{quote.text}"</blockquote>
+        {quote.author && <div>— {quote.author}</div>}
+        {quote.tag && <div>{quote.tag}</div>}
       </li>
     )}
   </ul>

--- a/app/src/com/QuoteUpsert.jsx
+++ b/app/src/com/QuoteUpsert.jsx
@@ -1,0 +1,52 @@
+import React, {useState} from 'react'
+import {db} from '@/db/conx.js'
+
+export default function QuoteUpsert({open, onClose}) {
+  const [text, setText] = useState('')
+  const [author, setAuthor] = useState('')
+  const [tag, setTag] = useState('')
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    try {
+      await db.quotes.put({text, author, tag})
+      setText('')
+      setAuthor('')
+      setTag('')
+      onClose?.()
+    } catch (err) {
+      console.error('Failed to save quote', err)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="modal" style={{position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.5)'}}>
+      <div style={{background: 'white', margin: '10% auto', padding: '1rem', maxWidth: '400px'}}>
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label>Quote<br/>
+              <textarea value={text} onChange={e => setText(e.target.value)} required />
+            </label>
+          </div>
+          <div>
+            <label>Author<br/>
+              <input value={author} onChange={e => setAuthor(e.target.value)} />
+            </label>
+          </div>
+          <div>
+            <label>Tags<br/>
+              <input value={tag} onChange={e => setTag(e.target.value)} />
+            </label>
+          </div>
+          <div style={{marginTop: '1rem'}}>
+            <button type="submit">Save</button>
+            <button type="button" onClick={onClose} style={{marginLeft: '0.5rem'}}>Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add modal component for creating quotes with text, author and tags
- wire Add Quote button and add import/export buttons for JSON backup
- display author and tag fields in quote list and clean unused state

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6becc6110832792324e9bfda10623